### PR TITLE
More views and simplification

### DIFF
--- a/aggregator-mock/Cargo.toml
+++ b/aggregator-mock/Cargo.toml
@@ -12,14 +12,14 @@ path = "src/lib.rs"
 wasm-output-mode = [ "elrond-wasm-node",]
 
 [dependencies.elrond-wasm]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-derive]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-node]
-version = "0.14.1"
+version = "0.14.2"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.14.1"
+version = "0.14.2"

--- a/aggregator-mock/abi/Cargo.toml
+++ b/aggregator-mock/abi/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-debug]
-version = "0.14.1"
+version = "0.14.2"

--- a/aggregator-mock/wasm/Cargo.toml
+++ b/aggregator-mock/wasm/Cargo.toml
@@ -26,5 +26,5 @@ default-features = false
 path = ".."
 
 [dependencies.elrond-wasm-output]
-version = "0.14.1"
+version = "0.14.2"
 features = [ "wasm-output-mode",]

--- a/common/transaction/Cargo.toml
+++ b/common/transaction/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-derive]
-version = "0.14.1"
+version = "0.14.2"

--- a/egld-esdt-swap/Cargo.toml
+++ b/egld-esdt-swap/Cargo.toml
@@ -12,14 +12,14 @@ path = "src/lib.rs"
 wasm-output-mode = [ "elrond-wasm-node",]
 
 [dependencies.elrond-wasm]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-derive]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-node]
-version = "0.14.1"
+version = "0.14.2"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.14.1"
+version = "0.14.2"

--- a/egld-esdt-swap/abi/Cargo.toml
+++ b/egld-esdt-swap/abi/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-debug]
-version = "0.14.1"
+version = "0.14.2"

--- a/egld-esdt-swap/wasm/Cargo.toml
+++ b/egld-esdt-swap/wasm/Cargo.toml
@@ -26,5 +26,5 @@ default-features = false
 path = ".."
 
 [dependencies.elrond-wasm-output]
-version = "0.14.1"
+version = "0.14.2"
 features = [ "wasm-output-mode",]

--- a/esdt-safe/Cargo.toml
+++ b/esdt-safe/Cargo.toml
@@ -15,14 +15,14 @@ wasm-output-mode = [ "elrond-wasm-node",]
 path = "../common/transaction"
 
 [dependencies.elrond-wasm]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-derive]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-node]
-version = "0.14.1"
+version = "0.14.2"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.14.1"
+version = "0.14.2"

--- a/esdt-safe/abi/Cargo.toml
+++ b/esdt-safe/abi/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-debug]
-version = "0.14.1"
+version = "0.14.2"

--- a/esdt-safe/wasm/Cargo.toml
+++ b/esdt-safe/wasm/Cargo.toml
@@ -26,5 +26,5 @@ default-features = false
 path = ".."
 
 [dependencies.elrond-wasm-output]
-version = "0.14.1"
+version = "0.14.2"
 features = [ "wasm-output-mode",]

--- a/ethereum-fee-prepay/Cargo.toml
+++ b/ethereum-fee-prepay/Cargo.toml
@@ -19,14 +19,14 @@ branch = "sc-bridge-stable"
 path = "../common/transaction"
 
 [dependencies.elrond-wasm]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-derive]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-node]
-version = "0.14.1"
+version = "0.14.2"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.14.1"
+version = "0.14.2"

--- a/ethereum-fee-prepay/wasm/Cargo.toml
+++ b/ethereum-fee-prepay/wasm/Cargo.toml
@@ -26,5 +26,5 @@ default-features = false
 path = ".."
 
 [dependencies.elrond-wasm-output]
-version = "0.14.1"
+version = "0.14.2"
 features = [ "wasm-output-mode",]

--- a/multi-transfer-esdt/Cargo.toml
+++ b/multi-transfer-esdt/Cargo.toml
@@ -12,14 +12,14 @@ path = "src/lib.rs"
 wasm-output-mode = [ "elrond-wasm-node",]
 
 [dependencies.elrond-wasm]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-derive]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-node]
-version = "0.14.1"
+version = "0.14.2"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.14.1"
+version = "0.14.2"

--- a/multi-transfer-esdt/abi/Cargo.toml
+++ b/multi-transfer-esdt/abi/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-debug]
-version = "0.14.1"
+version = "0.14.2"

--- a/multi-transfer-esdt/wasm/Cargo.toml
+++ b/multi-transfer-esdt/wasm/Cargo.toml
@@ -26,5 +26,5 @@ default-features = false
 path = ".."
 
 [dependencies.elrond-wasm-output]
-version = "0.14.1"
+version = "0.14.2"
 features = [ "wasm-output-mode",]

--- a/multisig/Cargo.toml
+++ b/multisig/Cargo.toml
@@ -17,14 +17,14 @@ wasm-output-mode = [
 path = "../common/transaction"
 
 [dependencies.elrond-wasm]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-derive]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-node]
-version = "0.14.1"
+version = "0.14.2"
 optional = true
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.14.1"
+version = "0.14.2"

--- a/multisig/abi/Cargo.toml
+++ b/multisig/abi/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.14.1"
+version = "0.14.2"
 
 [dependencies.elrond-wasm-debug]
-version = "0.14.1"
+version = "0.14.2"

--- a/multisig/src/proxy.rs
+++ b/multisig/src/proxy.rs
@@ -18,7 +18,9 @@ pub trait EgldEsdtSwap {
 pub trait EsdtSafe {
     fn addTokenToWhitelist(&self, token_id: TokenIdentifier) -> ContractCall<BigUint, ()>;
     fn removeTokenFromWhitelist(&self, token_id: TokenIdentifier) -> ContractCall<BigUint, ()>;
-    fn getNextPendingTransaction(&self) -> ContractCall<BigUint, OptionalMultiResultTx<BigUint>>;
+    fn getNextPendingTransaction(
+        &self,
+    ) -> ContractCall<BigUint, OptionalResult<TxAsMultiResult<BigUint>>>;
     fn setTransactionStatus(
         &self,
         sender: Address,

--- a/multisig/wasm/Cargo.toml
+++ b/multisig/wasm/Cargo.toml
@@ -21,7 +21,7 @@ features = ["wasm-output-mode"]
 default-features = false
 
 [dependencies.elrond-wasm-output]
-version = "0.14.1"
+version = "0.14.2"
 features = ["wasm-output-mode"]
 
 [workspace]


### PR DESCRIPTION
- improved Transaction struct to include Nonce instead of carrying it around separately
- getNextPendingTx no longer requires the propose-sign-execute flow
- ability to link an eth tx hash to an action ID in the case of transfers from Ethereum -> Elrond.
- view functions to help with the previous point