### PR TITLE
More views and simplification

### DIFF
--- a/multisig/src/lib.rs
+++ b/multisig/src/lib.rs
@@ -656,17 +656,13 @@ pub trait Multisig {
         }
     }
 
-    /// Actions are cleared after execution, so a non-empty entry means the action was proposed
-    /// Returns "false" if the action ID is invalid
+    /// If the mapping was made, it means that the transfer action was proposed in the past
+    /// To check if it was executed as well, use the wasActionExecuted view
     #[view(wasTransferActionProposed)]
     fn was_transfer_action_proposed(&self, eth_tx_hash: H256) -> bool {
         let action_id = self.eth_tx_hash_to_action_id_mapping(&eth_tx_hash).get();
 
-        if self.is_valid_action_id(action_id) {
-            !self.action_mapper().item_is_empty(action_id)
-        } else {
-            false
-        }
+        self.is_valid_action_id(action_id)
     }
 
     // private

--- a/multisig/src/proxy.rs
+++ b/multisig/src/proxy.rs
@@ -18,7 +18,9 @@ pub trait EgldEsdtSwap {
 pub trait EsdtSafe {
     fn addTokenToWhitelist(&self, token_id: TokenIdentifier) -> ContractCall<BigUint, ()>;
     fn removeTokenFromWhitelist(&self, token_id: TokenIdentifier) -> ContractCall<BigUint, ()>;
-    fn getNextPendingTransaction(&self) -> ContractCall<BigUint, OptionalMultiResultTx<BigUint>>;
+    fn getNextPendingTransaction(
+        &self,
+    ) -> ContractCall<BigUint, OptionalResult<TxAsMultiResult<BigUint>>>;
     fn setTransactionStatus(
         &self,
         sender: Address,


### PR DESCRIPTION
- improved Transaction struct to include Nonce instead of carrying it around separately
- getNextPendingTx no longer requires the propose-sign-execute flow
- ability to link an eth tx hash to an action ID in the case of transfers from Ethereum -> Elrond.
- view functions to help with the previous point