### PR TITLE
empty batch bug fix

### DIFF
--- a/esdt-safe/mandos/get_next_pending_tx.scen.json
+++ b/esdt-safe/mandos/get_next_pending_tx.scen.json
@@ -14,7 +14,7 @@
                 "value": "0",
                 "function": "getNextTransactionBatch",
                 "arguments": [],
-                "gasLimit": "20,000,000",
+                "gasLimit": "30,000,000",
                 "gasPrice": "0"
             },
             "expect": {

--- a/esdt-safe/mandos/get_next_tx_batch.scen.json
+++ b/esdt-safe/mandos/get_next_tx_batch.scen.json
@@ -14,7 +14,7 @@
                 "value": "0",
                 "function": "getNextTransactionBatch",
                 "arguments": [],
-                "gasLimit": "20,000,000",
+                "gasLimit": "30,000,000",
                 "gasPrice": "0"
             },
             "expect": {

--- a/esdt-safe/src/lib.rs
+++ b/esdt-safe/src/lib.rs
@@ -94,6 +94,13 @@ pub trait EsdtSafe {
     fn get_next_transaction_batch(&self) -> SCResult<EsdtSafeTxBatch<Self::BigUint>> {
         self.require_caller_owner()?;
 
+        if self.pending_transaction_address_nonce_list().is_empty() {
+            return Ok(EsdtSafeTxBatch {
+                batch_id: 0,
+                transactions: Vec::new()
+            })
+        }
+
         let mut tx_batch = Vec::new();
         let mut first_tx_block_nonce = 0;
         let max_tx_batch_size = self.max_tx_batch_size().get();

--- a/multisig/interaction/snippets.sh
+++ b/multisig/interaction/snippets.sh
@@ -2,14 +2,14 @@
 # Bob will be the single board member
 # Quorum size will be 1
 
-ALICE="/home/elrond/elrond-sdk/erdpy/testnet/wallets/users/alice.pem"
-BOB="/home/elrond/elrond-sdk/erdpy/testnet/wallets/users/bob.pem"
-CAROL="/home/elrond/elrond-sdk/erdpy/testnet/wallets/users/carol.pem"
+ALICE="/home/elrond/Downloads/testnetWalletKey.pem"
+BOB="/home/elrond/elrond-sdk-erdpy/erdpy/testnet/wallets/users/bob.pem"
+CAROL="/home/elrond/elrond-sdk-erdpy/erdpy/testnet/wallets/users/carol.pem"
 
-ADDRESS=$(erdpy data load --key=address-testnet)
+ADDRESS=erd1qqqqqqqqqqqqqpgqp4wjgyws7gu60kqdyhemdrmddmhz8xkv6j7quc7hph
 DEPLOY_TRANSACTION=$(erdpy data load --key=deployTransaction-testnet)
-PROXY=https://testnet-gateway.elrond.com
-CHAIN_ID=T
+PROXY=https://devnet-gateway.elrond.com
+CHAIN_ID=D
 
 RELAYER_REQUIRED_STAKE=0x03e8 # 1000
 ESDT_ISSUE_COST=0x4563918244f40000 # 5 eGLD
@@ -19,18 +19,18 @@ BOB_ADDRESS=0x8049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f8
 ESDT_SYSTEM_SC_ADDRESS=erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u
 
 # Setup and aggregator first, then put its address hex-encoded in this variable
-AGGREGATOR_ADDRESS=0x
+AGGREGATOR_ADDRESS=0xb0d1c728af35de1ff2dab61d960bab6c756e875d73dac06bdcd59cc3790ed4bc
 
 #########################################################################
 ################## Update after issueing the tokens #####################
 #########################################################################
-WRAPPED_EGLD_TOKEN_ID=0x
-WRAPPED_ETH_TOKEN_ID=0x
+WRAPPED_EGLD_TOKEN_ID=0x5745474c442d353937613761
+WRAPPED_ETH_TOKEN_ID=0x574554482d626631623064
 
 deploy() {
     local SLASH_AMOUNT=0x01f4 # 500
 
-    erdpy --verbose contract deploy --project=${PROJECT} --recall-nonce --pem=${ALICE} --gas-limit=200000000 --arguments ${RELAYER_REQUIRED_STAKE} ${SLASH_AMOUNT} 0x01 ${BOB_ADDRESS} --send --outfile="deploy-testnet.interaction.json" --proxy=${PROXY} --chain=${CHAIN_ID} || return
+    erdpy --verbose contract deploy --project=${PROJECT} --recall-nonce --pem=${ALICE} --gas-limit=300000000 --arguments ${RELAYER_REQUIRED_STAKE} ${SLASH_AMOUNT} 0x01 ${BOB_ADDRESS} --send --outfile="deploy-testnet.interaction.json" --proxy=${PROXY} --chain=${CHAIN_ID} || return
 
     TRANSACTION=$(erdpy data parse --file="deploy-testnet.interaction.json" --expression="data['emitted_tx']['hash']")
     ADDRESS=$(erdpy data parse --file="deploy-testnet.interaction.json" --expression="data['emitted_tx']['address']")
@@ -63,7 +63,7 @@ deployChildContracts() {
 stake() {
     local RELAYER_REQUIRED_STAKE_DECIMAL=1000
 
-    erdpy --verbose contract call ${ADDRESS} --recall-nonce --pem=${BOB} --gas-limit=25000000 --function="stake" --value=${RELAYER_REQUIRED_STAKE_DECIMAL} --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    erdpy --verbose contract call ${ADDRESS} --recall-nonce --pem=${BOB} --gas-limit=30000000 --function="stake" --value=${RELAYER_REQUIRED_STAKE_DECIMAL} --send --proxy=${PROXY} --chain=${CHAIN_ID}
 }
 
 unstake() {
@@ -80,7 +80,7 @@ issueWrappedEgld() {
     local CAN_ADD_SPECIAL_ROLES=0x63616e4164645370656369616c526f6c6573 # "canAddSpecialRoles"
     local TRUE=0x74727565 # "true"
 
-    erdpy --verbose contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce --pem=${ALICE} --gas-limit=60000000 --value=5000000000000000000 --function="issue" --arguments ${TOKEN_DISPLAY_NAME} ${TOKEN_TICKER} ${INITIAL_SUPPLY} ${NR_DECIMALS} ${CAN_ADD_SPECIAL_ROLES} ${TRUE} --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    erdpy --verbose contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce --pem=${ALICE} --gas-limit=60000000 --value=50000000000000000 --function="issue" --arguments ${TOKEN_DISPLAY_NAME} ${TOKEN_TICKER} ${INITIAL_SUPPLY} ${NR_DECIMALS} ${CAN_ADD_SPECIAL_ROLES} ${TRUE} --send --proxy=${PROXY} --chain=${CHAIN_ID}
 }
 
 issueWrappedEth() {
@@ -91,7 +91,7 @@ issueWrappedEth() {
     local CAN_ADD_SPECIAL_ROLES=0x63616e4164645370656369616c526f6c6573 # "canAddSpecialRoles"
     local TRUE=0x74727565 # "true"
 
-    erdpy --verbose contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce --pem=${ALICE} --gas-limit=60000000 --value=5000000000000000000 --function="issue" --arguments ${TOKEN_DISPLAY_NAME} ${TOKEN_TICKER} ${INITIAL_SUPPLY} ${NR_DECIMALS} ${CAN_ADD_SPECIAL_ROLES} ${TRUE} --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    erdpy --verbose contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce --pem=${ALICE} --gas-limit=60000000 --value=50000000000000000 --function="issue" --arguments ${TOKEN_DISPLAY_NAME} ${TOKEN_TICKER} ${INITIAL_SUPPLY} ${NR_DECIMALS} ${CAN_ADD_SPECIAL_ROLES} ${TRUE} --send --proxy=${PROXY} --chain=${CHAIN_ID}
 }
 
 # Set Local Roles
@@ -103,7 +103,7 @@ setLocalRolesEgldEsdtSwap() {
     local LOCAL_MINT_ROLE=0x45534454526f6c654c6f63616c4d696e74 # "ESDTRoleLocalMint"
     local LOCAL_BURN_ROLE=0x45534454526f6c654c6f63616c4275726e # "ESDTRoleLocalBurn"
 
-    erdpy --verbose contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce --pem=${ALICE} --gas-limit=60000000 --function="setSpecialRole" --arguments ${WRAPPED_EGLD_TOKEN_ID} ${ADDRESS_HEX} ${LOCAL_MINT_ROLE} ${LOCAL_BURN_ROLE} --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    erdpy --verbose contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce --pem=${ALICE} --gas-limit=60000000 --function="setSpecialRole" --arguments ${WRAPPED_EGLD_TOKEN_ID} 0x${ADDRESS_HEX} ${LOCAL_MINT_ROLE} ${LOCAL_BURN_ROLE} --send --proxy=${PROXY} --chain=${CHAIN_ID}
 }
 
 # Note: increase sleep time if needed
@@ -114,12 +114,12 @@ setLocalRolesEsdtSafe() {
     local LOCAL_BURN_ROLE=0x45534454526f6c654c6f63616c4275726e # "ESDTRoleLocalBurn"
 
     # set roles for WrappedEgld
-    erdpy --verbose contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce --pem=${ALICE} --gas-limit=60000000 --function="setSpecialRole" --arguments ${WRAPPED_EGLD_TOKEN_ID} ${ADDRESS_HEX} ${LOCAL_BURN_ROLE} --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    erdpy --verbose contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce --pem=${ALICE} --gas-limit=60000000 --function="setSpecialRole" --arguments ${WRAPPED_EGLD_TOKEN_ID} 0x${ADDRESS_HEX} ${LOCAL_BURN_ROLE} --send --proxy=${PROXY} --chain=${CHAIN_ID}
 
     sleep 10
 
     # set roles for WrappedEth
-    erdpy --verbose contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce --pem=${ALICE} --gas-limit=60000000 --function="setSpecialRole" --arguments ${WRAPPED_ETH_TOKEN_ID} ${ADDRESS_HEX} ${LOCAL_BURN_ROLE} --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    erdpy --verbose contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce --pem=${ALICE} --gas-limit=60000000 --function="setSpecialRole" --arguments ${WRAPPED_ETH_TOKEN_ID} 0x${ADDRESS_HEX} ${LOCAL_BURN_ROLE} --send --proxy=${PROXY} --chain=${CHAIN_ID}
 }
 
 # Note: increase sleep time if needed
@@ -130,12 +130,12 @@ setLocalRolesMultiTransferEsdt() {
     local LOCAL_MINT_ROLE=0x45534454526f6c654c6f63616c4d696e74 # "ESDTRoleLocalMint"
 
     # set roles for WrappedEgld
-    erdpy --verbose contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce --pem=${ALICE} --gas-limit=60000000 --function="setSpecialRole" --arguments ${WRAPPED_EGLD_TOKEN_ID} ${ADDRESS_HEX} ${LOCAL_MINT_ROLE} --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    erdpy --verbose contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce --pem=${ALICE} --gas-limit=60000000 --function="setSpecialRole" --arguments ${WRAPPED_EGLD_TOKEN_ID} 0x${ADDRESS_HEX} ${LOCAL_MINT_ROLE} --send --proxy=${PROXY} --chain=${CHAIN_ID}
 
     sleep 10
 
     # set roles for WrappedEth
-    erdpy --verbose contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce --pem=${ALICE} --gas-limit=60000000 --function="setSpecialRole" --arguments ${WRAPPED_ETH_TOKEN_ID} ${ADDRESS_HEX} ${LOCAL_MINT_ROLE} --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    erdpy --verbose contract call ${ESDT_SYSTEM_SC_ADDRESS} --recall-nonce --pem=${ALICE} --gas-limit=60000000 --function="setSpecialRole" --arguments ${WRAPPED_ETH_TOKEN_ID} 0x${ADDRESS_HEX} ${LOCAL_MINT_ROLE} --send --proxy=${PROXY} --chain=${CHAIN_ID}
 }
 
 # MultiTransferEsdtCalls
@@ -193,6 +193,19 @@ setTransactionRejected() {
 
     # Bob executes the action
     erdpy --verbose contract call ${ADDRESS} --recall-nonce --pem=${BOB} --gas-limit=100000000 --function="performAction" --arguments ${ACTION_INDEX} --send --proxy=${PROXY} --chain=${CHAIN_ID}
+}
+
+addBoardMember() {
+    # Bob proposes action
+    #erdpy --verbose contract call ${ADDRESS} --recall-nonce --pem=${BOB} --gas-limit=100000000 --function="proposeAddBoardMember" --arguments 0xb0d1c728af35de1ff2dab61d960bab6c756e875d73dac06bdcd59cc3790ed4bc --send --proxy=${PROXY} --chain=${CHAIN_ID}
+
+    # Bob signs the action
+    #getActionLastIndex
+    #bobSign
+    #sleep 10
+
+    # Bob executes the action
+    erdpy --verbose contract call ${ADDRESS} --recall-nonce --pem=${BOB} --gas-limit=100000000 --function="performAction" --arguments 0x02 --send --proxy=${PROXY} --chain=${CHAIN_ID}
 }
 
 # views
@@ -257,7 +270,7 @@ parsedAddressToBech32() {
 }
 
 bobSign() {
-    erdpy --verbose contract call ${ADDRESS} --recall-nonce --pem=${BOB} --gas-limit=25000000 --function="sign" --arguments ${ACTION_INDEX} --send --proxy=${PROXY} --chain=${CHAIN_ID}
+    erdpy --verbose contract call ${ADDRESS} --recall-nonce --pem=${BOB} --gas-limit=50000000 --function="sign" --arguments ${ACTION_INDEX} --send --proxy=${PROXY} --chain=${CHAIN_ID}
 }
 
 bech32ToHex() {

--- a/multisig/interaction/snippets.sh
+++ b/multisig/interaction/snippets.sh
@@ -2,14 +2,14 @@
 # Bob will be the single board member
 # Quorum size will be 1
 
-ALICE="/home/elrond/Downloads/testnetWalletKey.pem"
+ALICE="/home/elrond/elrond-sdk/erdpy/testnet/wallets/users/alice.pem"
 BOB="/home/elrond/elrond-sdk-erdpy/erdpy/testnet/wallets/users/bob.pem"
 CAROL="/home/elrond/elrond-sdk-erdpy/erdpy/testnet/wallets/users/carol.pem"
 
-ADDRESS=erd1qqqqqqqqqqqqqpgqp4wjgyws7gu60kqdyhemdrmddmhz8xkv6j7quc7hph
+ADDRESS=$(erdpy data load --key=address-testnet)
 DEPLOY_TRANSACTION=$(erdpy data load --key=deployTransaction-testnet)
-PROXY=https://devnet-gateway.elrond.com
-CHAIN_ID=D
+PROXY=https://testnet-gateway.elrond.com
+CHAIN_ID=T
 
 RELAYER_REQUIRED_STAKE=0x03e8 # 1000
 ESDT_ISSUE_COST=0x4563918244f40000 # 5 eGLD
@@ -24,8 +24,8 @@ AGGREGATOR_ADDRESS=0xb0d1c728af35de1ff2dab61d960bab6c756e875d73dac06bdcd59cc3790
 #########################################################################
 ################## Update after issueing the tokens #####################
 #########################################################################
-WRAPPED_EGLD_TOKEN_ID=0x5745474c442d353937613761
-WRAPPED_ETH_TOKEN_ID=0x574554482d626631623064
+WRAPPED_EGLD_TOKEN_ID=0x
+WRAPPED_ETH_TOKEN_ID=0x
 
 deploy() {
     local SLASH_AMOUNT=0x01f4 # 500

--- a/multisig/src/lib.rs
+++ b/multisig/src/lib.rs
@@ -90,7 +90,9 @@ pub trait Multisig:
         let esdt_safe_batch_id = esdt_safe_tx_batch.batch_id;
         let batch_len = esdt_safe_tx_batch.transactions.len();
 
-        self.current_tx_batch().set(&esdt_safe_tx_batch);
+        if batch_len > 0 {
+            self.current_tx_batch().set(&esdt_safe_tx_batch);
+        }
 
         // convert into MultiResult for easier parsing
         let mut result_vec = Vec::with_capacity(batch_len);

--- a/multisig/src/lib.rs
+++ b/multisig/src/lib.rs
@@ -250,13 +250,9 @@ pub trait Multisig:
     ) -> usize {
         let transfers_as_tuples = self.transfers_multiarg_to_tuples_vec(transfers);
 
-        match self
-            .batch_id_to_action_id_mapping(batch_id)
+        self.batch_id_to_action_id_mapping(batch_id)
             .get(&transfers_as_tuples)
-        {
-            Some(action_id) => action_id,
-            None => 0,
-        }
+            .unwrap_or(0)
     }
 
     #[view(wasSetCurrentTransactionBatchStatusActionProposed)]
@@ -277,13 +273,9 @@ pub trait Multisig:
         esdt_safe_batch_id: usize,
         #[var_args] expected_tx_batch_status: VarArgs<TransactionStatus>,
     ) -> usize {
-        match self
-            .action_id_for_set_current_transaction_batch_status(esdt_safe_batch_id)
+        self.action_id_for_set_current_transaction_batch_status(esdt_safe_batch_id)
             .get(&expected_tx_batch_status.0)
-        {
-            Some(action_id) => action_id,
-            None => 0,
-        }
+            .unwrap_or(0)
     }
 
     // private


### PR DESCRIPTION
Empty batch in EsdtSafe would block the multisig SC, as there would be no transactions to set the status for (although, in theory, one could propose a SetTransactionStatus action with 0 statuses, it's better to avoid this)

Also fixed a few clippy warnings.