### PR TITLE
status for batches after execution

### DIFF
--- a/multisig/mandos/ethereum_to_elrond_tx_batch_ok.scen.json
+++ b/multisig/mandos/ethereum_to_elrond_tx_batch_ok.scen.json
@@ -85,9 +85,23 @@
             }
         },
         {
+            "step": "scQuery",
+            "txId": "try-query-statuses-before-execution",
+            "tx": {
+                "to": "sc:multisig",
+                "function": "getStatusesAfterExecution",
+                "arguments": [
+                    "1"
+                ]
+            },
+            "expect": {
+                "out": []
+            }
+        },
+        {
             "step": "scCall",
             "txId": "perform-action-transfer",
-            "comment": "output is duplicated due to execute_on_dest_context results being propagated to the initial caller",
+            "comment": "output is from execute_on_dest_context results being propagated to the initial caller",
             "tx": {
                 "from": "address:relayer1",
                 "to": "sc:multisig",
@@ -105,11 +119,27 @@
                 "out": [
                     "1", "str:GWEI", "str:EGLD", "10", "0",
                     "1", "str:GWEI", "str:ETH", "1", "0",
-                    "3", "3",
                     "3", "3"
                 ],
                 "gas": "*",
                 "refund": "*"
+            }
+        },
+        {
+            "step": "scQuery",
+            "txId": "query-statuses",
+            "tx": {
+                "to": "sc:multisig",
+                "function": "getStatusesAfterExecution",
+                "arguments": [
+                    "1"
+                ]
+            },
+            "expect": {
+                "out": [
+                    "3",
+                    "3"
+                ]
             }
         },
         {

--- a/multisig/mandos/ethereum_to_elrond_tx_batch_rejected.scen.json
+++ b/multisig/mandos/ethereum_to_elrond_tx_batch_rejected.scen.json
@@ -87,7 +87,7 @@
         {
             "step": "scCall",
             "txId": "perform-action-transfer",
-            "comment": "output is duplicated due to execute_on_dest_context results being propagated to the initial caller",
+            "comment": "output is from execute_on_dest_context results being propagated to the initial caller",
             "tx": {
                 "from": "address:relayer1",
                 "to": "sc:multisig",
@@ -103,11 +103,27 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "4", "4",
                     "4", "4"
                 ],
                 "gas": "*",
                 "refund": "*"
+            }
+        },
+        {
+            "step": "scQuery",
+            "txId": "query-statuses",
+            "tx": {
+                "to": "sc:multisig",
+                "function": "getStatusesAfterExecution",
+                "arguments": [
+                    "1"
+                ]
+            },
+            "expect": {
+                "out": [
+                    "4",
+                    "4"
+                ]
             }
         }
     ]

--- a/multisig/mandos/setup.scen.json
+++ b/multisig/mandos/setup.scen.json
@@ -209,7 +209,9 @@
                         "str:user_address_to_id|address:relayer2": "2",
                         "str:user_count": "2",
                         "str:user_id_to_address|u32:1": "address:relayer1",
-                        "str:user_id_to_address|u32:2": "address:relayer2"
+                        "str:user_id_to_address|u32:2": "address:relayer2",
+
+                        "str:statusesAfterExecution": "u64:0|u32:0"
                     },
                     "code": "file:../output/multisig.wasm"
                 },

--- a/multisig/src/setup.rs
+++ b/multisig/src/setup.rs
@@ -114,6 +114,10 @@ pub trait SetupModule:
         let esdt_safe_address = opt_esdt_safe_address.ok_or("EsdtSafe deploy failed")?;
         self.esdt_safe_address().set(&esdt_safe_address);
 
+        // is set only so we don't have to check for "empty" on the very first call
+        // trying to deserialize a tuple from an empty storage entry would crash
+        self.statuses_after_execution().set(&(0, Vec::new()));
+
         Ok(())
     }
 

--- a/multisig/src/storage.rs
+++ b/multisig/src/storage.rs
@@ -2,8 +2,8 @@ elrond_wasm::imports!();
 
 use eth_address::EthAddress;
 use multi_transfer_esdt::SingleTransferTuple;
-use transaction::TransactionStatus;
 use transaction::esdt_safe_batch::EsdtSafeTxBatch;
+use transaction::TransactionStatus;
 
 use crate::action::Action;
 use crate::user_role::UserRole;
@@ -77,6 +77,11 @@ pub trait StorageModule {
         &self,
         batch_id: u64,
     ) -> MapMapper<Self::Storage, Vec<SingleTransferTuple<Self::BigUint>>, usize>;
+
+    #[storage_mapper("statusesAfterExecution")]
+    fn statuses_after_execution(
+        &self,
+    ) -> SingleValueMapper<Self::Storage, (u64, Vec<TransactionStatus>)>;
 
     #[storage_mapper("actionIdForSetCurrentTransactionBatchStatus")]
     fn action_id_for_set_current_transaction_batch_status(


### PR DESCRIPTION
The `getStatusesAfterExecution` view function will return the statuses for the selected batch ID after execution.

To not pollute storage with unneeded statuses, the previous status list is overwritten on the next "performAction" of the Ethereum -> Elrond tx action