### PR TITLE
remove default whitelist

### DIFF
--- a/common/contract-proxies/src/lib.rs
+++ b/common/contract-proxies/src/lib.rs
@@ -20,12 +20,7 @@ pub mod esdt_safe_proxy {
     #[elrond_wasm_derive::proxy]
     pub trait EsdtSafe {
         #[init]
-        fn init(
-            &self,
-            fee_estimator_contract_address: Address,
-            eth_tx_gas_limit: Self::BigUint,
-            #[var_args] token_whitelist: VarArgs<TokenIdentifier>,
-        );
+        fn init(&self, fee_estimator_contract_address: Address, eth_tx_gas_limit: Self::BigUint);
 
         #[endpoint(setFeeEstimatorContractAddress)]
         fn set_fee_estimator_contract_address(&self, new_address: Address);
@@ -82,12 +77,7 @@ pub mod multi_transfer_esdt_proxy {
     #[elrond_wasm_derive::proxy]
     pub trait MultiTransferEsdt {
         #[init]
-        fn init(
-            &self,
-            fee_estimator_contract_address: Address,
-            eth_tx_gas_limit: Self::BigUint,
-            #[var_args] token_whitelist: VarArgs<TokenIdentifier>,
-        );
+        fn init(&self, fee_estimator_contract_address: Address, eth_tx_gas_limit: Self::BigUint);
 
         #[endpoint(setFeeEstimatorContractAddress)]
         fn set_fee_estimator_contract_address(&self, new_address: Address);

--- a/common/contract-proxies/src/lib.rs
+++ b/common/contract-proxies/src/lib.rs
@@ -26,7 +26,7 @@ pub mod esdt_safe_proxy {
         fn set_fee_estimator_contract_address(&self, new_address: Address);
 
         #[endpoint(setDefaultPricePerGwei)]
-        fn set_default_price_per_gwei(
+        fn set_default_price_per_gas_unit(
             &self,
             token_id: TokenIdentifier,
             default_gwei_price: Self::BigUint,
@@ -40,7 +40,7 @@ pub mod esdt_safe_proxy {
             &self,
             token_id: TokenIdentifier,
             #[var_args] opt_ticker: OptionalArg<BoxedBytes>,
-            #[var_args] opt_default_price_per_gwei: OptionalArg<Self::BigUint>,
+            #[var_args] opt_default_price_per_gas_unit: OptionalArg<Self::BigUint>,
         );
 
         #[endpoint(removeTokenFromWhitelist)]
@@ -83,7 +83,7 @@ pub mod multi_transfer_esdt_proxy {
         fn set_fee_estimator_contract_address(&self, new_address: Address);
 
         #[endpoint(setDefaultPricePerGwei)]
-        fn set_default_price_per_gwei(
+        fn set_default_price_per_gas_unit(
             &self,
             token_id: TokenIdentifier,
             default_gwei_price: Self::BigUint,
@@ -97,7 +97,7 @@ pub mod multi_transfer_esdt_proxy {
             &self,
             token_id: TokenIdentifier,
             #[var_args] opt_ticker: OptionalArg<BoxedBytes>,
-            #[var_args] opt_default_price_per_gwei: OptionalArg<Self::BigUint>,
+            #[var_args] opt_default_price_per_gas_unit: OptionalArg<Self::BigUint>,
         );
 
         #[endpoint(removeTokenFromWhitelist)]

--- a/common/fee-estimator-module/src/lib.rs
+++ b/common/fee-estimator-module/src/lib.rs
@@ -15,12 +15,12 @@ pub trait FeeEstimatorModule {
 
     #[only_owner]
     #[endpoint(setDefaultPricePerGwei)]
-    fn set_default_price_per_gwei(
+    fn set_default_price_per_gas_unit(
         &self,
         token_id: TokenIdentifier,
         default_gwei_price: Self::BigUint,
     ) {
-        self.default_price_per_gwei(&token_id)
+        self.default_price_per_gas_unit(&token_id)
             .set(&default_gwei_price);
     }
 
@@ -32,16 +32,16 @@ pub trait FeeEstimatorModule {
 
     #[view(calculateRequiredFee)]
     fn calculate_required_fee(&self, token_id: &TokenIdentifier) -> Self::BigUint {
-        let price_per_gwei = self.get_price_per_gwei(token_id);
+        let price_per_gas_unit = self.get_price_per_gas_unit(token_id);
         let gas_limit = self.eth_tx_gas_limit().get();
 
-        price_per_gwei * gas_limit
+        price_per_gas_unit * gas_limit
     }
 
-    fn get_price_per_gwei(&self, token_id: &TokenIdentifier) -> Self::BigUint {
+    fn get_price_per_gas_unit(&self, token_id: &TokenIdentifier) -> Self::BigUint {
         let opt_price = self.get_aggregator_mapping(&GWEI_STRING.into(), token_id);
 
-        opt_price.unwrap_or_else(|| self.default_price_per_gwei(token_id).get())
+        opt_price.unwrap_or_else(|| self.default_price_per_gas_unit(token_id).get())
     }
 
     fn get_aggregator_mapping(
@@ -80,7 +80,7 @@ pub trait FeeEstimatorModule {
 
     #[view(getDefaultPricePerGwei)]
     #[storage_mapper("defaultPricePerGwei")]
-    fn default_price_per_gwei(
+    fn default_price_per_gas_unit(
         &self,
         token_id: &TokenIdentifier,
     ) -> SingleValueMapper<Self::Storage, Self::BigUint>;

--- a/common/token-module/src/lib.rs
+++ b/common/token-module/src/lib.rs
@@ -43,7 +43,7 @@ pub trait TokenModule: fee_estimator_module::FeeEstimatorModule {
         &self,
         token_id: TokenIdentifier,
         #[var_args] opt_ticker: OptionalArg<BoxedBytes>,
-        #[var_args] opt_default_price_per_gwei: OptionalArg<Self::BigUint>,
+        #[var_args] opt_default_price_per_gas_unit: OptionalArg<Self::BigUint>,
     ) -> SCResult<()> {
         self.require_valid_token_id(&token_id)?;
 
@@ -53,9 +53,9 @@ pub trait TokenModule: fee_estimator_module::FeeEstimatorModule {
         };
         self.token_ticker(&token_id).set(&ticker);
 
-        if let Some(default_price_per_gwei) = opt_default_price_per_gwei.into_option() {
-            self.default_price_per_gwei(&token_id)
-                .set(&default_price_per_gwei);
+        if let Some(default_price_per_gas_unit) = opt_default_price_per_gas_unit.into_option() {
+            self.default_price_per_gas_unit(&token_id)
+                .set(&default_price_per_gas_unit);
         }
 
         let _ = self.token_whitelist().insert(token_id);
@@ -67,7 +67,7 @@ pub trait TokenModule: fee_estimator_module::FeeEstimatorModule {
     #[endpoint(removeTokenFromWhitelist)]
     fn remove_token_from_whitelist(&self, token_id: TokenIdentifier) {
         self.token_ticker(&token_id).clear();
-        self.default_price_per_gwei(&token_id).clear();
+        self.default_price_per_gas_unit(&token_id).clear();
 
         let _ = self.token_whitelist().remove(&token_id);
     }

--- a/esdt-safe/mandos/setup_accounts.scen.json
+++ b/esdt-safe/mandos/setup_accounts.scen.json
@@ -47,10 +47,30 @@
                 "value": "0",
                 "arguments": [
                     "sc:price_aggregator",
-                    "150,000",
-                    "str:BRIDGE-123456"
+                    "150,000"
                 ],
                 "gasLimit": "20,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "message": "",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "add-token-1",
+            "tx": {
+                "from": "address:owner",
+                "to": "sc:esdt_safe",
+                "value": "0",
+                "function": "addTokenToWhitelist",
+                "arguments": [
+                    "str:BRIDGE-123456"
+                ],
+                "gasLimit": "50,000,000",
                 "gasPrice": "0"
             },
             "expect": {

--- a/esdt-safe/src/lib.rs
+++ b/esdt-safe/src/lib.rs
@@ -19,20 +19,10 @@ pub trait EsdtSafe: fee_estimator_module::FeeEstimatorModule + token_module::Tok
         &self,
         fee_estimator_contract_address: Address,
         eth_tx_gas_limit: Self::BigUint,
-        #[var_args] token_whitelist: VarArgs<TokenIdentifier>,
     ) -> SCResult<()> {
         self.fee_estimator_contract_address()
             .set(&fee_estimator_contract_address);
         self.eth_tx_gas_limit().set(&eth_tx_gas_limit);
-
-        for token in token_whitelist.into_vec() {
-            self.require_valid_token_id(&token)?;
-
-            let token_ticker = self.ticker_from_token_id(&token);
-            self.token_ticker(&token).set(&token_ticker);
-
-            let _ = self.token_whitelist().insert(token);
-        }
 
         self.max_tx_batch_size()
             .set_if_empty(&DEFAULT_MAX_TX_BATCH_SIZE);

--- a/multi-transfer-esdt/src/lib.rs
+++ b/multi-transfer-esdt/src/lib.rs
@@ -14,19 +14,9 @@ pub trait MultiTransferEsdt:
         &self,
         fee_estimator_contract_address: Address,
         eth_tx_gas_limit: Self::BigUint,
-        #[var_args] token_whitelist: VarArgs<TokenIdentifier>,
     ) -> SCResult<()> {
         self.fee_estimator_contract_address()
             .set(&fee_estimator_contract_address);
-
-        for token in token_whitelist.into_vec() {
-            self.require_valid_token_id(&token)?;
-
-            let token_ticker = self.ticker_from_token_id(&token);
-            self.token_ticker(&token).set(&token_ticker);
-
-            self.token_whitelist().insert(token);
-        }
 
         self.eth_tx_gas_limit().set(&eth_tx_gas_limit);
 

--- a/multisig/mandos/setup.scen.json
+++ b/multisig/mandos/setup.scen.json
@@ -70,16 +70,11 @@
                 {
                     "creatorAddress": "sc:multisig",
                     "creatorNonce": "0",
-                    "newAddress": "sc:egld_esdt_swap"
-                },
-                {
-                    "creatorAddress": "sc:multisig",
-                    "creatorNonce": "1",
                     "newAddress": "sc:multi_transfer"
                 },
                 {
                     "creatorAddress": "sc:multisig",
-                    "creatorNonce": "2",
+                    "creatorNonce": "1",
                     "newAddress": "sc:esdt_safe"
                 }
             ]
@@ -118,14 +113,11 @@
                 "value": "0",
                 "function": "deployChildContracts",
                 "arguments": [
-                    "file:../../egld-esdt-swap/output/egld-esdt-swap.wasm",
                     "file:../../multi-transfer-esdt/output/multi-transfer-esdt.wasm",
                     "file:../../esdt-safe/output/esdt-safe.wasm",
                     "sc:price_aggregator",
                     "150,000",
-                    "10,000",
-                    "str:EGLD-123456",
-                    "str:ETH-123456"
+                    "10,000"
                 ],
                 "gasLimit": "100,000,000",
                 "gasPrice": "0"
@@ -139,20 +131,96 @@
             }
         },
         {
+            "step": "scCall",
+            "txId": "add-token-1-safe",
+            "tx": {
+                "from": "address:owner",
+                "to": "sc:multisig",
+                "value": "0",
+                "function": "esdtSafeAddTokenToWhitelist",
+                "arguments": [
+                    "str:ETH-123456"
+                ],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "message": "",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "add-token-2-safe",
+            "tx": {
+                "from": "address:owner",
+                "to": "sc:multisig",
+                "value": "0",
+                "function": "esdtSafeAddTokenToWhitelist",
+                "arguments": [
+                    "str:EGLD-123456"
+                ],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "message": "",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "add-token-1-multi",
+            "tx": {
+                "from": "address:owner",
+                "to": "sc:multisig",
+                "value": "0",
+                "function": "multiTransferEsdtaddTokenToWhitelist",
+                "arguments": [
+                    "str:ETH-123456"
+                ],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "message": "",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "add-token-2-multi",
+            "tx": {
+                "from": "address:owner",
+                "to": "sc:multisig",
+                "value": "0",
+                "function": "multiTransferEsdtaddTokenToWhitelist",
+                "arguments": [
+                    "str:EGLD-123456"
+                ],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "message": "",
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
             "step": "checkState",
             "accounts": {
                 "address:owner": {
                     "nonce": "*",
                     "balance": "0",
                     "storage": {}
-                },
-                "sc:egld_esdt_swap": {
-                    "nonce": "0",
-                    "balance": "0",
-                    "storage": {
-                        "str:wrappedEgldTokenId": "str:EGLD-123456"
-                    },
-                    "code": "file:../../egld-esdt-swap/output/egld-esdt-swap.wasm"
                 },
                 "sc:multi_transfer": {
                     "nonce": "0",
@@ -202,7 +270,6 @@
                     "nonce": "*",
                     "balance": "0",
                     "storage": {
-                        "str:egldEsdtSwapAddress": "sc:egld_esdt_swap",
                         "str:esdtSafeAddress": "sc:esdt_safe",
                         "str:multiTransferEsdtAddress": "sc:multi_transfer",
 
@@ -245,7 +312,6 @@
                     "storage": {
                         "str:wrappedEgldTokenId": "str:EGLD-123456"
                     },
-                    "owner": "sc:multisig",
                     "code": "file:../../egld-esdt-swap/output/egld-esdt-swap.wasm"
                 },
                 "sc:multi_transfer": {

--- a/multisig/mandos/upgrade_child_sc.scen.json
+++ b/multisig/mandos/upgrade_child_sc.scen.json
@@ -14,10 +14,9 @@
                 "value": "0",
                 "function": "upgradeChildContract",
                 "arguments": [
-                    "sc:egld_esdt_swap",
-                    "file:../../multi-transfer-esdt/output/multi-transfer-esdt.wasm",
-                    "sc:price_aggregator",
-                    "10,000"
+                    "sc:esdt_safe",
+                    "file:../../egld-esdt-swap/output/egld-esdt-swap.wasm",
+                    "str:EGLD-123456"
                 ],
                 "gasLimit": "200,000,000",
                 "gasPrice": "0"
@@ -33,25 +32,15 @@
         {
             "step": "checkState",
             "accounts": {
-                "sc:egld_esdt_swap": {
+                "sc:esdt_safe": {
                     "nonce": "0",
                     "balance": "0",
-                    "esdt": {
-                        "str:EGLD-123456": {
-                            "balance": "0",
-                            "roles": [
-                                "ESDTRoleLocalMint",
-                                "ESDTRoleLocalBurn"
-                            ]
-                        }
-                    },
+                    "esdt": "*",
                     "storage": {
                         "str:wrappedEgldTokenId": "str:EGLD-123456",
-                        "str:feeEstimatorContractAddress": "sc:price_aggregator",
-                        "str:ethTxGasLimit": "10,000",
-                        "str:tokenTicker|nested:str:GWEI": "str:GWEI"
+                        "+": ""
                     },
-                    "code": "file:../../multi-transfer-esdt/output/multi-transfer-esdt.wasm"
+                    "code": "file:../../egld-esdt-swap/output/egld-esdt-swap.wasm"
                 },
                 "+": {}
             }

--- a/multisig/src/setup.rs
+++ b/multisig/src/setup.rs
@@ -276,13 +276,13 @@ pub trait SetupModule:
 
     #[only_owner]
     #[endpoint(changeDefaultPricePerGwei)]
-    fn change_default_price_per_gwei(&self, token_id: TokenIdentifier, new_value: Self::BigUint) {
+    fn change_default_price_per_gas_unit(&self, token_id: TokenIdentifier, new_value: Self::BigUint) {
         self.setup_esdt_safe_proxy(self.esdt_safe_address().get())
-            .set_default_price_per_gwei(token_id.clone(), new_value.clone())
+            .set_default_price_per_gas_unit(token_id.clone(), new_value.clone())
             .execute_on_dest_context();
 
         self.setup_multi_transfer_esdt_proxy(self.multi_transfer_esdt_address().get())
-            .set_default_price_per_gwei(token_id, new_value)
+            .set_default_price_per_gas_unit(token_id, new_value)
             .execute_on_dest_context();
     }
 

--- a/multisig/src/storage.rs
+++ b/multisig/src/storage.rs
@@ -108,10 +108,6 @@ pub trait StorageModule {
 
     // SC addresses
 
-    #[view(getEgldEsdtSwapAddress)]
-    #[storage_mapper("egldEsdtSwapAddress")]
-    fn egld_esdt_swap_address(&self) -> SingleValueMapper<Self::Storage, Address>;
-
     #[view(getEsdtSafeAddress)]
     #[storage_mapper("esdtSafeAddress")]
     fn esdt_safe_address(&self) -> SingleValueMapper<Self::Storage, Address>;


### PR DESCRIPTION
- removed EGLD-ESDT swap contract from the whole setup. It can be deployed separately (the multisig doesn't even need to know its address).
- removed the default enforced whitelist. Now all tokens have to manually be added to the whitelist