### PR TITLE
refund batch in eth to elrond flow

### DIFF
--- a/common/eth-address/src/lib.rs
+++ b/common/eth-address/src/lib.rs
@@ -3,7 +3,7 @@
 elrond_wasm::derive_imports!();
 use elrond_wasm::{
     api::{Handle, ManagedTypeApi},
-    types::{ManagedByteArray, ManagedType, ManagedVecItem},
+    types::{ManagedBuffer, ManagedByteArray, ManagedType, ManagedVecItem},
 };
 
 pub const ETH_ADDRESS_LEN: usize = 20;
@@ -18,6 +18,10 @@ impl<M: ManagedTypeApi> EthAddress<M> {
         Self {
             raw_addr: ManagedByteArray::new_from_bytes(api, &[0u8; ETH_ADDRESS_LEN]),
         }
+    }
+
+    pub fn as_managed_buffer(&self) -> &ManagedBuffer<M> {
+        self.raw_addr.as_managed_buffer()
     }
 }
 

--- a/common/transaction/src/esdt_safe_batch.rs
+++ b/common/transaction/src/esdt_safe_batch.rs
@@ -22,5 +22,5 @@ impl<M: ManagedTypeApi> ManagedDefault<M> for EsdtSafeTxBatch<M> {
     }
 }
 
-pub type EsdtSafeTxBatchSplitInFields<M> =
+pub type TxBatchSplitInFields<M> =
     MultiResult2<u64, ManagedMultiResultVec<M, TxAsMultiResult<M>>>;

--- a/common/tx-batch-module/Cargo.toml
+++ b/common/tx-batch-module/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tx-batch-module"
+version = "0.0.0"
+authors = [ "dorin-iancu <dorin.iancu@elrond.com>",]
+edition = "2018"
+
+[dependencies.elrond-wasm]
+version = "0.22.10"
+
+[dependencies.transaction]
+path = "../transaction"
+
+[dev-dependencies.elrond-wasm-debug]
+version = "0.22.10"

--- a/common/tx-batch-module/src/lib.rs
+++ b/common/tx-batch-module/src/lib.rs
@@ -1,0 +1,196 @@
+#![no_std]
+
+use transaction::{esdt_safe_batch::TxBatchSplitInFields, Transaction, MIN_BLOCKS_FOR_FINALITY};
+
+elrond_wasm::imports!();
+elrond_wasm::derive_imports!();
+
+#[elrond_wasm::module]
+pub trait TxBatchModule {
+    // endpoints - owner-only
+
+    #[only_owner]
+    #[endpoint(setMaxTxBatchSize)]
+    fn set_max_tx_batch_size(&self, new_max_tx_batch_size: usize) -> SCResult<()> {
+        require!(
+            new_max_tx_batch_size > 0,
+            "Max tx batch size must be more than 0"
+        );
+
+        self.max_tx_batch_size().set(&new_max_tx_batch_size);
+
+        Ok(())
+    }
+
+    #[only_owner]
+    #[endpoint(setMaxTxBatchBlockDuration)]
+    fn set_max_tx_batch_block_duration(
+        &self,
+        new_max_tx_batch_block_duration: u64,
+    ) -> SCResult<()> {
+        require!(
+            new_max_tx_batch_block_duration > 0,
+            "Max tx batch block duration must be more than 0"
+        );
+
+        self.max_tx_batch_block_duration()
+            .set(&new_max_tx_batch_block_duration);
+
+        Ok(())
+    }
+
+    // views
+
+    #[view(getCurrentTxBatch)]
+    fn get_current_tx_batch(&self) -> OptionalResult<TxBatchSplitInFields<Self::Api>> {
+        let first_batch_id = self.first_batch_id().get();
+        let first_batch = self.pending_batches(first_batch_id).get();
+
+        if self.is_batch_full(&first_batch) && self.is_batch_final(&first_batch) {
+            let mut result_vec = ManagedMultiResultVec::new();
+            for tx in first_batch.iter() {
+                result_vec.push(tx.into_multiresult());
+            }
+
+            return OptionalResult::Some((first_batch_id, result_vec).into());
+        }
+
+        OptionalResult::None
+    }
+
+    #[view(getBatch)]
+    fn get_batch(&self, batch_id: u64) -> OptionalResult<TxBatchSplitInFields<Self::Api>> {
+        let tx_batch = self.pending_batches(batch_id).get();
+        if tx_batch.is_empty() {
+            return OptionalResult::None;
+        }
+
+        let mut result_vec = ManagedMultiResultVec::new();
+        for tx in tx_batch.iter() {
+            result_vec.push(tx.into_multiresult());
+        }
+
+        return OptionalResult::Some((batch_id, result_vec).into());
+    }
+
+    // private
+
+    fn add_to_batch(&self, transaction: Transaction<Self::Api>) {
+        let last_batch_id = self.last_batch_id().get();
+        let mut last_batch = self.pending_batches(last_batch_id).get();
+
+        if self.is_batch_full(&last_batch) {
+            self.create_new_batch(transaction);
+        } else {
+            last_batch.push(transaction);
+            self.pending_batches(last_batch_id).set(&last_batch);
+        }
+    }
+
+    #[allow(clippy::vec_init_then_push)]
+    fn create_new_batch(&self, transaction: Transaction<Self::Api>) {
+        let last_batch_id = self.last_batch_id().get();
+        let new_batch_id = last_batch_id + 1;
+
+        let mut new_batch = ManagedVec::new();
+        new_batch.push(transaction);
+
+        self.pending_batches(new_batch_id).set(&new_batch);
+        self.last_batch_id().set(&new_batch_id);
+    }
+
+    fn is_batch_full(&self, tx_batch: &ManagedVec<Transaction<Self::Api>>) -> bool {
+        if tx_batch.is_empty() {
+            return false;
+        }
+
+        let max_batch_size = self.max_tx_batch_size().get();
+        if tx_batch.len() == max_batch_size {
+            return true;
+        }
+
+        let current_block_nonce = self.blockchain().get_block_nonce();
+        let first_tx_in_batch_block_nonce = match tx_batch.get(0) {
+            Some(tx) => tx.block_nonce,
+            None => return false,
+        };
+
+        // reorg protection
+        if current_block_nonce < first_tx_in_batch_block_nonce {
+            return false;
+        }
+
+        let block_diff = current_block_nonce - first_tx_in_batch_block_nonce;
+        let max_tx_batch_block_duration = self.max_tx_batch_block_duration().get();
+
+        block_diff > max_tx_batch_block_duration
+    }
+
+    fn is_batch_final(&self, tx_batch: &ManagedVec<Transaction<Self::Api>>) -> bool {
+        let batch_len = tx_batch.len();
+        let last_tx_in_batch = match tx_batch.get(batch_len - 1) {
+            Some(tx) => tx,
+            None => return false,
+        };
+
+        let current_block = self.blockchain().get_block_nonce();
+
+        // reorg protection
+        if current_block < last_tx_in_batch.block_nonce {
+            return false;
+        }
+
+        let block_diff = current_block - last_tx_in_batch.block_nonce;
+
+        block_diff > MIN_BLOCKS_FOR_FINALITY
+    }
+
+    fn clear_first_batch(&self) {
+        let first_batch_id = self.first_batch_id().get();
+        let new_first_batch_id = first_batch_id + 1;
+
+        // for the case when the last existing batch was processed
+        // otherwise, we'd create a batch with the same ID again
+        self.last_batch_id().update(|last_batch_id| {
+            if *last_batch_id == first_batch_id {
+                *last_batch_id = new_first_batch_id;
+            }
+        });
+        self.first_batch_id().set(&new_first_batch_id);
+        self.pending_batches(first_batch_id).clear();
+    }
+
+    fn get_and_save_next_tx_id(&self) -> u64 {
+        self.last_tx_nonce().update(|last_tx_nonce| {
+            *last_tx_nonce += 1;
+            *last_tx_nonce
+        })
+    }
+
+    // storage
+
+    #[view(getFirstBatchId)]
+    #[storage_mapper("firstBatchId")]
+    fn first_batch_id(&self) -> SingleValueMapper<u64>;
+
+    #[view(getLastBatchId)]
+    #[storage_mapper("lastBatchId")]
+    fn last_batch_id(&self) -> SingleValueMapper<u64>;
+
+    #[storage_mapper("pendingBatches")]
+    fn pending_batches(
+        &self,
+        batch_id: u64,
+    ) -> SingleValueMapper<ManagedVec<Transaction<Self::Api>>>;
+
+    #[storage_mapper("lastTxNonce")]
+    fn last_tx_nonce(&self) -> SingleValueMapper<u64>;
+
+    // configurable
+
+    #[storage_mapper("maxTxBatchSize")]
+    fn max_tx_batch_size(&self) -> SingleValueMapper<usize>;
+
+    #[storage_mapper("maxTxBatchBlockDuration")]
+    fn max_tx_batch_block_duration(&self) -> SingleValueMapper<u64>;
+}

--- a/esdt-safe/Cargo.toml
+++ b/esdt-safe/Cargo.toml
@@ -20,6 +20,9 @@ path = "../common/fee-estimator-module"
 [dependencies.token-module]
 path = "../common/token-module"
 
+[dependencies.tx-batch-module]
+path = "../common/tx-batch-module"
+
 [dependencies.elrond-wasm]
 version = "0.22.10"
 

--- a/esdt-safe/mandos/create_another_tx_ok.scen.json
+++ b/esdt-safe/mandos/create_another_tx_ok.scen.json
@@ -63,16 +63,16 @@
                             {
                                 "1-block_nonce": "u64:0",
                                 "2-nonce": "u64:1",
-                                "3-from": "address:user1",
-                                "4-to": "0x0102030405060708091011121314151617181920",
+                                "3-from": "u32:32|address:user1",
+                                "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                                 "5-token_identifier": "nested:str:BRIDGE-123456",
                                 "6-amount": "biguint:400"
                             },
                             {
                                 "1-block_nonce": "u64:0",
                                 "2-nonce": "u64:2",
-                                "3-from": "address:user2",
-                                "4-to": "0x0102030405060708091011121314151617181920",
+                                "3-from": "u32:32|address:user2",
+                                "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                                 "5-token_identifier": "nested:str:BRIDGE-123456",
                                 "6-amount": "biguint:900"
                             }

--- a/esdt-safe/mandos/create_another_tx_too_late_for_batch.scen.json
+++ b/esdt-safe/mandos/create_another_tx_too_late_for_batch.scen.json
@@ -79,16 +79,16 @@
                             {
                                 "1-block_nonce": "u64:0",
                                 "2-nonce": "u64:1",
-                                "3-from": "address:user1",
-                                "4-to": "0x0102030405060708091011121314151617181920",
+                                "3-from": "u32:32|address:user1",
+                                "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                                 "5-token_identifier": "nested:str:BRIDGE-123456",
                                 "6-amount": "biguint:400"
                             },
                             {
                                 "1-block_nonce": "u64:0",
                                 "2-nonce": "u64:2",
-                                "3-from": "address:user2",
-                                "4-to": "0x0102030405060708091011121314151617181920",
+                                "3-from": "u32:32|address:user2",
+                                "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                                 "5-token_identifier": "nested:str:BRIDGE-123456",
                                 "6-amount": "biguint:900"
                             }
@@ -96,8 +96,8 @@
                         "str:pendingBatches|u64:1": {
                             "1-block_nonce": "u64:101",
                             "2-nonce": "u64:3",
-                            "3-from": "address:user2",
-                            "4-to": "0x0102030405060708091011121314151617181920",
+                            "3-from": "u32:32|address:user2",
+                            "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                             "5-token_identifier": "nested:str:BRIDGE-123456",
                             "6-amount": "biguint:100"
                         },

--- a/esdt-safe/mandos/create_transaction_ok.scen.json
+++ b/esdt-safe/mandos/create_transaction_ok.scen.json
@@ -62,8 +62,8 @@
                         "str:pendingBatches|u64:0": {
                             "1-block_nonce": "u64:0",
                             "2-nonce": "u64:1",
-                            "3-from": "address:user1",
-                            "4-to": "0x0102030405060708091011121314151617181920",
+                            "3-from": "u32:32|address:user1",
+                            "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                             "5-token_identifier": "nested:str:BRIDGE-123456",
                             "6-amount": "biguint:400"
                         },

--- a/esdt-safe/mandos/zero_fees.scen.json
+++ b/esdt-safe/mandos/zero_fees.scen.json
@@ -101,8 +101,8 @@
                         "str:pendingBatches|u64:0": {
                             "1-block_nonce": "u64:0",
                             "2-nonce": "u64:1",
-                            "3-from": "address:user1",
-                            "4-to": "0x0102030405060708091011121314151617181920",
+                            "3-from": "u32:32|address:user1",
+                            "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                             "5-token_identifier": "nested:str:BRIDGE-123456",
                             "6-amount": "biguint:1,500,400"
                         },

--- a/esdt-safe/src/lib.rs
+++ b/esdt-safe/src/lib.rs
@@ -6,14 +6,17 @@ elrond_wasm::derive_imports!();
 
 use eth_address::*;
 use fee_estimator_module::GWEI_STRING;
-use transaction::esdt_safe_batch::EsdtSafeTxBatchSplitInFields;
 use transaction::*;
 
 const DEFAULT_MAX_TX_BATCH_SIZE: usize = 10;
-const DEFAULT_MAX_TX_BATCH_BLOCK_DURATION: u64 = 100;
+const DEFAULT_MAX_TX_BATCH_BLOCK_DURATION: u64 = 100; // ~10 minutes
 
 #[elrond_wasm::contract]
-pub trait EsdtSafe: fee_estimator_module::FeeEstimatorModule + token_module::TokenModule {
+pub trait EsdtSafe:
+    fee_estimator_module::FeeEstimatorModule
+    + token_module::TokenModule
+    + tx_batch_module::TxBatchModule
+{
     #[init]
     fn init(
         &self,
@@ -33,38 +36,6 @@ pub trait EsdtSafe: fee_estimator_module::FeeEstimatorModule + token_module::Tok
         let gwei_token_id = TokenIdentifier::from(GWEI_STRING);
         self.token_ticker(&gwei_token_id)
             .set(&gwei_token_id.as_managed_buffer());
-
-        Ok(())
-    }
-
-    // endpoints - owner-only
-
-    #[only_owner]
-    #[endpoint(setMaxTxBatchSize)]
-    fn set_max_tx_batch_size(&self, new_max_tx_batch_size: usize) -> SCResult<()> {
-        require!(
-            new_max_tx_batch_size > 0,
-            "Max tx batch size must be more than 0"
-        );
-
-        self.max_tx_batch_size().set(&new_max_tx_batch_size);
-
-        Ok(())
-    }
-
-    #[only_owner]
-    #[endpoint(setMaxTxBatchBlockDuration)]
-    fn set_max_tx_batch_block_duration(
-        &self,
-        new_max_tx_batch_block_duration: u64,
-    ) -> SCResult<()> {
-        require!(
-            new_max_tx_batch_block_duration > 0,
-            "Max tx batch block duration must be more than 0"
-        );
-
-        self.max_tx_batch_block_duration()
-            .set(&new_max_tx_batch_block_duration);
 
         Ok(())
     }
@@ -99,7 +70,11 @@ pub trait EsdtSafe: fee_estimator_module::FeeEstimatorModule + token_module::Tok
                     }
                 }
                 TransactionStatus::Rejected => {
-                    self.mark_refund(&tx.from, &tx.token_identifier, &tx.amount);
+                    self.mark_refund(
+                        &managed_buffer_to_managed_address(&tx.from),
+                        &tx.token_identifier,
+                        &tx.amount,
+                    );
                 }
                 _ => {
                     return sc_error!("Transaction status may only be set to Executed or Rejected")
@@ -107,17 +82,7 @@ pub trait EsdtSafe: fee_estimator_module::FeeEstimatorModule + token_module::Tok
             }
         }
 
-        let new_first_batch_id = first_batch_id + 1;
-
-        // for the case when the last existing batch was processed
-        // otherwise, we'd create a batch with the same ID again
-        self.last_batch_id().update(|last_batch_id| {
-            if *last_batch_id == first_batch_id {
-                *last_batch_id = new_first_batch_id;
-            }
-        });
-        self.first_batch_id().set(&new_first_batch_id);
-        self.pending_batches(batch_id).clear();
+        self.clear_first_batch();
 
         Ok(())
     }
@@ -149,15 +114,12 @@ pub trait EsdtSafe: fee_estimator_module::FeeEstimatorModule + token_module::Tok
 
         let actual_bridged_amount = payment_amount - required_fee;
         let caller = self.blockchain().get_caller();
-        let tx_nonce = self.last_tx_nonce().update(|last_tx_nonce| {
-            *last_tx_nonce += 1;
-            *last_tx_nonce
-        });
+        let tx_nonce = self.get_and_save_next_tx_id();
         let tx = Transaction {
             block_nonce: self.blockchain().get_block_nonce(),
             nonce: tx_nonce,
-            from: caller,
-            to,
+            from: managed_address_to_managed_buffer(&caller),
+            to: to.as_managed_buffer().clone(),
             token_identifier: payment_token,
             amount: actual_bridged_amount,
         };
@@ -180,40 +142,6 @@ pub trait EsdtSafe: fee_estimator_module::FeeEstimatorModule + token_module::Tok
         Ok(())
     }
 
-    // views
-
-    #[view(getCurrentTxBatch)]
-    fn get_current_tx_batch(&self) -> OptionalResult<EsdtSafeTxBatchSplitInFields<Self::Api>> {
-        let first_batch_id = self.first_batch_id().get();
-        let first_batch = self.pending_batches(first_batch_id).get();
-
-        if self.is_batch_full(&first_batch) && self.is_batch_final(&first_batch) {
-            let mut result_vec = ManagedMultiResultVec::new();
-            for tx in first_batch.iter() {
-                result_vec.push(tx.into_multiresult());
-            }
-
-            return OptionalResult::Some((first_batch_id, result_vec).into());
-        }
-
-        OptionalResult::None
-    }
-
-    #[view(getBatch)]
-    fn get_batch(&self, batch_id: u64) -> OptionalResult<EsdtSafeTxBatchSplitInFields<Self::Api>> {
-        let tx_batch = self.pending_batches(batch_id).get();
-        if tx_batch.is_empty() {
-            return OptionalResult::None;
-        }
-
-        let mut result_vec = ManagedMultiResultVec::new();
-        for tx in tx_batch.iter() {
-            result_vec.push(tx.into_multiresult());
-        }
-
-        return OptionalResult::Some((batch_id, result_vec).into());
-    }
-
     #[view(getRefundAmounts)]
     fn get_refund_amounts(
         &self,
@@ -231,76 +159,6 @@ pub trait EsdtSafe: fee_estimator_module::FeeEstimatorModule + token_module::Tok
     }
 
     // private
-
-    fn add_to_batch(&self, transaction: Transaction<Self::Api>) {
-        let last_batch_id = self.last_batch_id().get();
-        let mut last_batch = self.pending_batches(last_batch_id).get();
-
-        if self.is_batch_full(&last_batch) {
-            self.create_new_batch(transaction);
-        } else {
-            last_batch.push(transaction);
-            self.pending_batches(last_batch_id).set(&last_batch);
-        }
-    }
-
-    #[allow(clippy::vec_init_then_push)]
-    fn create_new_batch(&self, transaction: Transaction<Self::Api>) {
-        let last_batch_id = self.last_batch_id().get();
-        let new_batch_id = last_batch_id + 1;
-
-        let mut new_batch = ManagedVec::new();
-        new_batch.push(transaction);
-
-        self.pending_batches(new_batch_id).set(&new_batch);
-        self.last_batch_id().set(&new_batch_id);
-    }
-
-    fn is_batch_full(&self, tx_batch: &ManagedVec<Transaction<Self::Api>>) -> bool {
-        if tx_batch.is_empty() {
-            return false;
-        }
-
-        let max_batch_size = self.max_tx_batch_size().get();
-        if tx_batch.len() == max_batch_size {
-            return true;
-        }
-
-        let current_block_nonce = self.blockchain().get_block_nonce();
-        let first_tx_in_batch_block_nonce = match tx_batch.get(0) {
-            Some(tx) => tx.block_nonce,
-            None => return false,
-        };
-
-        // reorg protection
-        if current_block_nonce < first_tx_in_batch_block_nonce {
-            return false;
-        }
-
-        let block_diff = current_block_nonce - first_tx_in_batch_block_nonce;
-        let max_tx_batch_block_duration = self.max_tx_batch_block_duration().get();
-
-        block_diff > max_tx_batch_block_duration
-    }
-
-    fn is_batch_final(&self, tx_batch: &ManagedVec<Transaction<Self::Api>>) -> bool {
-        let batch_len = tx_batch.len();
-        let last_tx_in_batch = match tx_batch.get(batch_len - 1) {
-            Some(tx) => tx,
-            None => return false,
-        };
-
-        let current_block = self.blockchain().get_block_nonce();
-
-        // reorg protection
-        if current_block < last_tx_in_batch.block_nonce {
-            return false;
-        }
-
-        let block_diff = current_block - last_tx_in_batch.block_nonce;
-
-        block_diff > MIN_BLOCKS_FOR_FINALITY
-    }
 
     fn burn_esdt_token(&self, token_id: &TokenIdentifier, amount: &BigUint) {
         self.send().esdt_local_burn(token_id, 0, amount);
@@ -321,35 +179,10 @@ pub trait EsdtSafe: fee_estimator_module::FeeEstimatorModule + token_module::Tok
 
     // storage
 
-    #[view(getFirstBatchId)]
-    #[storage_mapper("firstBatchId")]
-    fn first_batch_id(&self) -> SingleValueMapper<u64>;
-
-    #[view(getLastBatchId)]
-    #[storage_mapper("lastBatchId")]
-    fn last_batch_id(&self) -> SingleValueMapper<u64>;
-
-    #[storage_mapper("pendingBatches")]
-    fn pending_batches(
-        &self,
-        batch_id: u64,
-    ) -> SingleValueMapper<ManagedVec<Transaction<Self::Api>>>;
-
-    #[storage_mapper("lastTxNonce")]
-    fn last_tx_nonce(&self) -> SingleValueMapper<u64>;
-
     #[storage_mapper("refundAmount")]
     fn refund_amount(
         &self,
         address: &ManagedAddress,
         token_id: &TokenIdentifier,
     ) -> SingleValueMapper<BigUint>;
-
-    // configurable
-
-    #[storage_mapper("maxTxBatchSize")]
-    fn max_tx_batch_size(&self) -> SingleValueMapper<usize>;
-
-    #[storage_mapper("maxTxBatchBlockDuration")]
-    fn max_tx_batch_block_duration(&self) -> SingleValueMapper<u64>;
 }

--- a/multi-transfer-esdt/Cargo.toml
+++ b/multi-transfer-esdt/Cargo.toml
@@ -17,6 +17,9 @@ path = "../common/fee-estimator-module"
 [dependencies.token-module]
 path = "../common/token-module"
 
+[dependencies.tx-batch-module]
+path = "../common/tx-batch-module"
+
 [dependencies.elrond-wasm]
 version = "0.22.10"
 

--- a/multi-transfer-esdt/mandos/batch_transfer_both_executed.scen.json
+++ b/multi-transfer-esdt/mandos/batch_transfer_both_executed.scen.json
@@ -14,8 +14,8 @@
                 "value": "0",
                 "function": "batchTransferEsdtToken",
                 "arguments": [
-                    "address:user1|nested:str:BRIDGE-123456|biguint:100,200",
-                    "address:user2|nested:str:WRAPPED-123456|biguint:500"
+                    "0x0102030405060708091011121314151617181920|address:user1|nested:str:BRIDGE-123456|biguint:100,200",
+                    "0x0102030405060708091011121314151617181920|address:user2|nested:str:WRAPPED-123456|biguint:500"
                 ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"
@@ -28,9 +28,7 @@
                     "str:GWEI",
                     "str:BRIDGE",
                     "10",
-                    "0",
-                    "3",
-                    "3"
+                    "0"
                 ],
                 "gas": "*",
                 "refund": "*"

--- a/multi-transfer-esdt/mandos/batch_transfer_both_failed.scen.json
+++ b/multi-transfer-esdt/mandos/batch_transfer_both_failed.scen.json
@@ -14,8 +14,8 @@
                 "value": "0",
                 "function": "batchTransferEsdtToken",
                 "arguments": [
-                    "sc:multi_transfer_esdt|nested:str:BRIDGE-123456|biguint:100,200",
-                    "sc:multi_transfer_esdt|nested:str:WRAPPED-123456|biguint:100,500"
+                    "0x0102030405060708091011121314151617181920|sc:multi_transfer_esdt|nested:str:BRIDGE-123456|biguint:100,200",
+                    "0x0102030405060708091011121314151617181920|sc:multi_transfer_esdt|nested:str:WRAPPED-123456|biguint:100,500"
                 ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"
@@ -23,12 +23,55 @@
             "expect": {
                 "status": "0",
                 "message": "",
-                "out": [
-                    "4",
-                    "4"
-                ],
+                "out": [],
                 "gas": "*",
                 "refund": "*"
+            }
+        },
+        {
+            "step": "scQuery",
+            "txId": "get-current-refund-tx-batch-too-early",
+            "tx": {
+                "to": "sc:multi_transfer_esdt",
+                "function": "getCurrentTxBatch",
+                "arguments": []
+            },
+            "expect": {
+                "out": []
+            }
+        },
+        {
+            "step": "setState",
+            "currentBlockInfo": {
+                "blockNonce": "4,000"
+            }
+        },
+        {
+            "step": "scQuery",
+            "txId": "get-current-refund-tx-batch",
+            "tx": {
+                "to": "sc:multi_transfer_esdt",
+                "function": "getCurrentTxBatch",
+                "arguments": []
+            },
+            "expect": {
+                "out": [
+                    "0",
+
+                    "0",
+                    "1",
+                    "0x0102030405060708091011121314151617181920",
+                    "sc:multi_transfer_esdt",
+                    "str:BRIDGE-123456",
+                    "100,200",
+
+                    "0",
+                    "2",
+                    "0x0102030405060708091011121314151617181920",
+                    "sc:multi_transfer_esdt",
+                    "str:WRAPPED-123456",
+                    "100,500"
+                ]
             }
         }
     ]

--- a/multi-transfer-esdt/mandos/batch_transfer_one_executed_one_failed.scen.json
+++ b/multi-transfer-esdt/mandos/batch_transfer_one_executed_one_failed.scen.json
@@ -14,8 +14,8 @@
                 "value": "0",
                 "function": "batchTransferEsdtToken",
                 "arguments": [
-                    "address:user1|nested:str:BRIDGE-123456|biguint:100,200",
-                    "sc:multi_transfer_esdt|nested:str:WRAPPED-123456|biguint:500"
+                    "0x0102030405060708091011121314151617181920|address:user1|nested:str:BRIDGE-123456|biguint:100,200",
+                    "0x0102030405060708091011121314151617181920|sc:multi_transfer_esdt|nested:str:WRAPPED-123456|biguint:500"
                 ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"
@@ -28,9 +28,7 @@
                     "str:GWEI",
                     "str:BRIDGE",
                     "10",
-                    "0",
-                    "3",
-                    "4"
+                    "0"
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -48,6 +46,33 @@
                     "storage": {}
                 },
                 "+": {}
+            }
+        },
+        {
+            "step": "setState",
+            "currentBlockInfo": {
+                "blockNonce": "4,000"
+            }
+        },
+        {
+            "step": "scQuery",
+            "txId": "get-current-refund-tx-batch",
+            "tx": {
+                "to": "sc:multi_transfer_esdt",
+                "function": "getCurrentTxBatch",
+                "arguments": []
+            },
+            "expect": {
+                "out": [
+                    "0",
+
+                    "0",
+                    "1",
+                    "0x0102030405060708091011121314151617181920",
+                    "sc:multi_transfer_esdt",
+                    "str:WRAPPED-123456",
+                    "500"
+                ]
             }
         }
     ]

--- a/multi-transfer-esdt/mandos/setup_accounts.scen.json
+++ b/multi-transfer-esdt/mandos/setup_accounts.scen.json
@@ -77,7 +77,9 @@
                     "storage": {
                         "str:feeEstimatorContractAddress": "sc:price_aggregator",
                         "str:ethTxGasLimit": "10,000",
-                        "str:tokenTicker|nested:str:GWEI": "str:GWEI"
+                        "str:tokenTicker|nested:str:GWEI": "str:GWEI",
+                        "str:maxTxBatchSize": "10",
+                        "str:maxTxBatchBlockDuration": "3,600"
                     },
                     "code": "file:../output/multi-transfer-esdt.wasm",
                     "owner": "address:owner"

--- a/multi-transfer-esdt/mandos/transfer_ok.scen.json
+++ b/multi-transfer-esdt/mandos/transfer_ok.scen.json
@@ -14,7 +14,7 @@
                 "value": "0",
                 "function": "batchTransferEsdtToken",
                 "arguments": [
-                    "address:user1|nested:str:BRIDGE-123456|biguint:100,200"
+                    "0x0102030405060708091011121314151617181920|address:user1|nested:str:BRIDGE-123456|biguint:100,200"
                 ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"
@@ -27,8 +27,7 @@
                     "str:GWEI",
                     "str:BRIDGE",
                     "10",
-                    "0",
-                    "3"
+                    "0"
                 ],
                 "gas": "*",
                 "refund": "*"

--- a/multi-transfer-esdt/mandos/two_transfers_same_token.scen.json
+++ b/multi-transfer-esdt/mandos/two_transfers_same_token.scen.json
@@ -14,8 +14,8 @@
                 "value": "0",
                 "function": "batchTransferEsdtToken",
                 "arguments": [
-                    "address:user1|nested:str:BRIDGE-123456|biguint:100,200",
-                    "address:user1|nested:str:BRIDGE-123456|biguint:100,200"
+                    "0x0102030405060708091011121314151617181920|address:user1|nested:str:BRIDGE-123456|biguint:100,200",
+                    "0x0102030405060708091011121314151617181920|address:user1|nested:str:BRIDGE-123456|biguint:100,200"
                 ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"
@@ -28,9 +28,7 @@
                     "str:GWEI",
                     "str:BRIDGE",
                     "10",
-                    "0",
-                    "3",
-                    "3"
+                    "0"
                 ],
                 "gas": "*",
                 "refund": "*"

--- a/multi-transfer-esdt/src/lib.rs
+++ b/multi-transfer-esdt/src/lib.rs
@@ -1,13 +1,18 @@
 #![no_std]
 
-use fee_estimator_module::GWEI_STRING;
-use transaction::{SingleTransferTuple, TransactionStatus};
-
 elrond_wasm::imports!();
+
+use fee_estimator_module::GWEI_STRING;
+use transaction::{managed_address_to_managed_buffer, SingleTransferTuple, Transaction};
+
+const DEFAULT_MAX_TX_BATCH_SIZE: usize = 10;
+const DEFAULT_MAX_TX_BATCH_BLOCK_DURATION: u64 = 3_600; // ~6 hours
 
 #[elrond_wasm::contract]
 pub trait MultiTransferEsdt:
-    fee_estimator_module::FeeEstimatorModule + token_module::TokenModule
+    fee_estimator_module::FeeEstimatorModule
+    + token_module::TokenModule
+    + tx_batch_module::TxBatchModule
 {
     #[init]
     fn init(
@@ -17,8 +22,12 @@ pub trait MultiTransferEsdt:
     ) -> SCResult<()> {
         self.fee_estimator_contract_address()
             .set(&fee_estimator_contract_address);
-
         self.eth_tx_gas_limit().set(&eth_tx_gas_limit);
+
+        self.max_tx_batch_size()
+            .set_if_empty(&DEFAULT_MAX_TX_BATCH_SIZE);
+        self.max_tx_batch_block_duration()
+            .set_if_empty(&DEFAULT_MAX_TX_BATCH_BLOCK_DURATION);
 
         // set ticker for "GWEI"
         let gwei_token_id = TokenIdentifier::from(GWEI_STRING);
@@ -33,55 +42,64 @@ pub trait MultiTransferEsdt:
     fn batch_transfer_esdt_token(
         &self,
         #[var_args] transfers: ManagedVarArgs<SingleTransferTuple<Self::Api>>,
-    ) -> ManagedMultiResultVec<TransactionStatus> {
-        let mut tx_statuses = ManagedVec::new();
+    ) {
         let mut cached_token_ids = ManagedVec::new();
         let mut cached_prices = ManagedVec::new();
 
         for transfer in transfers {
-            let to = &transfer.address;
-            let token_id = &transfer.token_id;
-            let amount = &transfer.amount;
-
-            if to.is_zero() || self.blockchain().is_smart_contract(to) {
-                tx_statuses.push(TransactionStatus::Rejected);
+            if transfer.to.is_zero() || self.blockchain().is_smart_contract(&transfer.to) {
+                self.add_refund_tx_to_batch(transfer);
                 continue;
             }
-            if !self.token_whitelist().contains(token_id)
-                || !self.is_local_role_set(token_id, &EsdtLocalRole::Mint)
+            if !self.token_whitelist().contains(&transfer.token_id)
+                || !self.is_local_role_set(&transfer.token_id, &EsdtLocalRole::Mint)
             {
-                tx_statuses.push(TransactionStatus::Rejected);
+                self.add_refund_tx_to_batch(transfer);
                 continue;
             }
 
             let queried_fee: BigUint;
-            let required_fee = match cached_token_ids.iter().position(|id| &id == token_id) {
+            let required_fee = match cached_token_ids
+                .iter()
+                .position(|id| id == transfer.token_id)
+            {
                 Some(index) => cached_prices.get(index).unwrap_or_else(|| BigUint::zero()),
                 None => {
-                    queried_fee = self.calculate_required_fee(token_id);
-                    cached_token_ids.push(token_id.clone());
+                    queried_fee = self.calculate_required_fee(&transfer.token_id);
+                    cached_token_ids.push(transfer.token_id.clone());
                     cached_prices.push(queried_fee.clone());
 
                     queried_fee
                 }
             };
 
-            if amount <= &required_fee {
-                tx_statuses.push(TransactionStatus::Rejected);
+            if transfer.amount <= required_fee {
+                self.add_refund_tx_to_batch(transfer);
                 continue;
             }
 
-            let amount_to_send = amount - &required_fee;
+            let amount_to_send = &transfer.amount - &required_fee;
 
-            self.accumulated_transaction_fees(token_id)
+            self.accumulated_transaction_fees(&transfer.token_id)
                 .update(|fees| *fees += required_fee);
 
-            self.send().esdt_local_mint(token_id, 0, amount);
-            self.send().direct(to, token_id, 0, &amount_to_send, &[]);
-
-            tx_statuses.push(TransactionStatus::Executed);
+            self.send()
+                .esdt_local_mint(&transfer.token_id, 0, &transfer.amount);
+            self.send()
+                .direct(&transfer.to, &transfer.token_id, 0, &amount_to_send, &[]);
         }
+    }
 
-        tx_statuses.into()
+    fn add_refund_tx_to_batch(&self, tx_tuple: SingleTransferTuple<Self::Api>) {
+        let tx = Transaction {
+            block_nonce: self.blockchain().get_block_nonce(),
+            nonce: self.get_and_save_next_tx_id(),
+            from: tx_tuple.from.as_managed_buffer().clone(),
+            to: managed_address_to_managed_buffer(&tx_tuple.to),
+            token_identifier: tx_tuple.token_id,
+            amount: tx_tuple.amount,
+        };
+
+        self.add_to_batch(tx);
     }
 }

--- a/multi-transfer-esdt/wasm/src/lib.rs
+++ b/multi-transfer-esdt/wasm/src/lib.rs
@@ -13,13 +13,19 @@ elrond_wasm_node::wasm_endpoints! {
         calculateRequiredFee
         distributeFees
         getAllKnownTokens
+        getBatch
+        getCurrentTxBatch
         getDefaultPricePerGasUnit
         getEthTxGasLimit
         getFeeEstimatorContractAddress
+        getFirstBatchId
+        getLastBatchId
         removeTokenFromWhitelist
         setDefaultPricePerGasUnit
         setEthTxGasLimit
         setFeeEstimatorContractAddress
+        setMaxTxBatchBlockDuration
+        setMaxTxBatchSize
         setTokenTicker
     )
 }

--- a/multisig/Cargo.toml
+++ b/multisig/Cargo.toml
@@ -14,11 +14,14 @@ path = "../common/transaction"
 [dependencies.eth-address]
 path = "../common/eth-address"
 
+[dependencies.fee-estimator-module]
+path = "../common/fee-estimator-module"
+
 [dependencies.token-module]
 path = "../common/token-module"
 
-[dependencies.fee-estimator-module]
-path = "../common/fee-estimator-module"
+[dependencies.tx-batch-module]
+path = "../common/tx-batch-module"
 
 [dependencies.esdt-safe]
 path = "../esdt-safe"

--- a/multisig/mandos/create_elrond_to_ethereum_tx_batch.scen.json
+++ b/multisig/mandos/create_elrond_to_ethereum_tx_batch.scen.json
@@ -121,8 +121,8 @@
                         "str:pendingBatches|u64:0": {
                             "1-block_nonce": "u64:0",
                             "2-nonce": "u64:1",
-                            "3-from": "address:user",
-                            "4-to": "0x0102030405060708091011121314151617181920",
+                            "3-from": "u32:32|address:user",
+                            "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                             "5-token_identifier": "nested:str:EGLD-123456",
                             "6-amount": "biguint:400"
                         },
@@ -203,16 +203,16 @@
                             {
                                 "1-block_nonce": "u64:0",
                                 "2-nonce": "u64:1",
-                                "3-from": "address:user",
-                                "4-to": "0x0102030405060708091011121314151617181920",
+                                "3-from": "u32:32|address:user",
+                                "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                                 "5-token_identifier": "nested:str:EGLD-123456",
                                 "6-amount": "biguint:400"
                             },
                             {
                                 "1-block_nonce": "u64:0",
                                 "2-nonce": "u64:2",
-                                "3-from": "address:user",
-                                "4-to": "0x0102030405060708091011121314151617181920",
+                                "3-from": "u32:32|address:user",
+                                "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                                 "5-token_identifier": "nested:str:ETH-123456",
                                 "6-amount": "biguint:350,000"
                             }

--- a/multisig/mandos/ethereum_to_elrond_tx_batch_ok.scen.json
+++ b/multisig/mandos/ethereum_to_elrond_tx_batch_ok.scen.json
@@ -15,8 +15,8 @@
                 "function": "proposeMultiTransferEsdtBatch",
                 "arguments": [
                     "1",
-                    "address:user", "str:EGLD-123456", "500,000",
-                    "address:user", "str:ETH-123456", "500,000"
+                    "0x0102030405060708091011121314151617181920", "address:user", "str:EGLD-123456", "500,000",
+                    "0x0102030405060708091011121314151617181920", "address:user", "str:ETH-123456", "500,000"
                 ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"
@@ -44,14 +44,16 @@
                             "3-transfers_len": "u32:2",
                             "4-transfers_vec": [
                                 {
-                                    "1-dest": "address:user",
-                                    "2-token_id": "nested:str:EGLD-123456",
-                                    "3-amount": "biguint:500,000"
+                                    "1-from": "0x0102030405060708091011121314151617181920",
+                                    "2-to": "address:user",
+                                    "3-token_id": "nested:str:EGLD-123456",
+                                    "4-amount": "biguint:500,000"
                                 },
                                 {
-                                    "1-dest": "address:user",
-                                    "2-token_id": "nested:str:ETH-123456",
-                                    "3-amount": "biguint:500,000"
+                                    "1-from": "0x0102030405060708091011121314151617181920",
+                                    "2-to": "address:user",
+                                    "3-token_id": "nested:str:ETH-123456",
+                                    "4-amount": "biguint:500,000"
                                 }
                             ]
                         },
@@ -85,20 +87,6 @@
             }
         },
         {
-            "step": "scQuery",
-            "txId": "try-query-statuses-before-execution",
-            "tx": {
-                "to": "sc:multisig",
-                "function": "getStatusesAfterExecution",
-                "arguments": [
-                    "1"
-                ]
-            },
-            "expect": {
-                "out": []
-            }
-        },
-        {
             "step": "scCall",
             "txId": "perform-action-transfer",
             "comment": "output is from execute_on_dest_context results being propagated to the initial caller",
@@ -118,60 +106,10 @@
                 "message": "",
                 "out": [
                     "1", "str:GWEI", "str:EGLD", "10", "0",
-                    "1", "str:GWEI", "str:ETH", "1", "0",
-                    "3", "3"
+                    "1", "str:GWEI", "str:ETH", "1", "0"
                 ],
                 "gas": "*",
                 "refund": "*"
-            }
-        },
-        {
-            "step": "setState",
-            "comment": "Block nonce was 0 before",
-            "currentBlockInfo": {
-                "blockNonce": "2"
-            }
-        },
-        {
-            "step": "scQuery",
-            "txId": "query-statuses-not-final",
-            "tx": {
-                "to": "sc:multisig",
-                "function": "getStatusesAfterExecution",
-                "arguments": [
-                    "1"
-                ]
-            },
-            "expect": {
-                "out": [
-                    "0x",
-                    "3",
-                    "3"
-                ]
-            }
-        },
-        {
-            "step": "setState",
-            "currentBlockInfo": {
-                "blockNonce": "3"
-            }
-        },
-        {
-            "step": "scQuery",
-            "txId": "query-statuses-final",
-            "tx": {
-                "to": "sc:multisig",
-                "function": "getStatusesAfterExecution",
-                "arguments": [
-                    "1"
-                ]
-            },
-            "expect": {
-                "out": [
-                    "0x01",
-                    "3",
-                    "3"
-                ]
             }
         },
         {

--- a/multisig/mandos/ethereum_to_elrond_tx_batch_rejected.scen.json
+++ b/multisig/mandos/ethereum_to_elrond_tx_batch_rejected.scen.json
@@ -15,8 +15,8 @@
                 "function": "proposeMultiTransferEsdtBatch",
                 "arguments": [
                     "1",
-                    "sc:egld_esdt_swap", "str:EGLD-123456", "500,000",
-                    "sc:egld_esdt_swap", "str:ETH-123456", "500,000"
+                    "0x0102030405060708091011121314151617181920", "sc:egld_esdt_swap", "str:EGLD-123456", "500,000",
+                    "0x0102030405060708091011121314151617181920", "sc:egld_esdt_swap", "str:ETH-123456", "500,000"
                 ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"
@@ -44,14 +44,16 @@
                             "3-transfers_len": "u32:2",
                             "4-transfers_vec": [
                                 {
-                                    "1-dest": "sc:egld_esdt_swap",
-                                    "2-token_id": "nested:str:EGLD-123456",
-                                    "3-amount": "biguint:500,000"
+                                    "1-from": "0x0102030405060708091011121314151617181920",
+                                    "2-to": "sc:egld_esdt_swap",
+                                    "3-token_id": "nested:str:EGLD-123456",
+                                    "4-amount": "biguint:500,000"
                                 },
                                 {
-                                    "1-dest": "sc:egld_esdt_swap",
-                                    "2-token_id": "nested:str:ETH-123456",
-                                    "3-amount": "biguint:500,000"
+                                    "1-from": "0x0102030405060708091011121314151617181920",
+                                    "2-to": "sc:egld_esdt_swap",
+                                    "3-token_id": "nested:str:ETH-123456",
+                                    "4-amount": "biguint:500,000"
                                 }
                             ]
                         },
@@ -96,15 +98,13 @@
                 "arguments": [
                     "1"
                 ],
-                "gasLimit": "50,000,000",
+                "gasLimit": "100,000,000",
                 "gasPrice": "0"
             },
             "expect": {
                 "status": "0",
                 "message": "",
-                "out": [
-                    "4", "4"
-                ],
+                "out": [],
                 "gas": "*",
                 "refund": "*"
             }
@@ -112,24 +112,34 @@
         {
             "step": "setState",
             "currentBlockInfo": {
-                "blockNonce": "3"
+                "blockNonce": "4,000"
             }
         },
         {
             "step": "scQuery",
-            "txId": "query-statuses",
+            "txId": "get-current-refund-tx-batch",
             "tx": {
                 "to": "sc:multisig",
-                "function": "getStatusesAfterExecution",
-                "arguments": [
-                    "1"
-                ]
+                "function": "getCurrentRefundBatch",
+                "arguments": []
             },
             "expect": {
                 "out": [
-                    "0x01",
-                    "4",
-                    "4"
+                    "0",
+
+                    "0",
+                    "1",
+                    "0x0102030405060708091011121314151617181920",
+                    "sc:egld_esdt_swap",
+                    "str:EGLD-123456",
+                    "500,000",
+
+                    "0",
+                    "2",
+                    "0x0102030405060708091011121314151617181920",
+                    "sc:egld_esdt_swap",
+                    "str:ETH-123456",
+                    "500,000"
                 ]
             }
         }

--- a/multisig/mandos/setup.scen.json
+++ b/multisig/mandos/setup.scen.json
@@ -45,6 +45,8 @@
                     },
                     "storage": {
                         "str:feeEstimatorContractAddress": "sc:price_aggregator",
+                        "str:maxTxBatchSize": "10",
+                        "str:maxTxBatchBlockDuration": "3,600",
                         "str:ethTxGasLimit": "10,000",
 
                         "str:tokenTicker|nested:str:GWEI": "str:GWEI",
@@ -184,9 +186,7 @@
                         "str:user_address_to_id|address:relayer2": "2",
                         "str:user_count": "2",
                         "str:user_id_to_address|u32:1": "address:relayer1",
-                        "str:user_id_to_address|u32:2": "address:relayer2",
-
-                        "str:statusesAfterExecution": "0xffffffffffffffff|0xffffffffffffffff|u32:0"
+                        "str:user_id_to_address|u32:2": "address:relayer2"
                     },
                     "code": "file:../output/multisig.wasm"
                 },

--- a/multisig/src/setup.rs
+++ b/multisig/src/setup.rs
@@ -5,6 +5,7 @@ use eth_address::EthAddress;
 
 use fee_estimator_module::ProxyTrait as _;
 use token_module::ProxyTrait as _;
+use tx_batch_module::ProxyTrait as _;
 
 #[elrond_wasm::module]
 pub trait SetupModule:

--- a/multisig/src/storage.rs
+++ b/multisig/src/storage.rs
@@ -7,13 +7,6 @@ use transaction::{SingleTransferTuple, TransactionStatus};
 use crate::action::Action;
 use crate::user_role::UserRole;
 
-#[derive(TopEncode, TopDecode)]
-pub struct StatusesAfterExecution<M: ManagedTypeApi> {
-    pub block_executed: u64,
-    pub batch_id: u64,
-    pub statuses: ManagedVec<M, TransactionStatus>,
-}
-
 #[elrond_wasm::module]
 pub trait StorageModule {
     /// Minimum number of signatures needed to perform any action.
@@ -68,9 +61,6 @@ pub trait StorageModule {
         &self,
         batch_id: u64,
     ) -> MapMapper<ManagedVec<SingleTransferTuple<Self::Api>>, usize>;
-
-    #[storage_mapper("statusesAfterExecution")]
-    fn statuses_after_execution(&self) -> SingleValueMapper<StatusesAfterExecution<Self::Api>>;
 
     #[storage_mapper("actionIdForSetCurrentTransactionBatchStatus")]
     fn action_id_for_set_current_transaction_batch_status(

--- a/multisig/src/util.rs
+++ b/multisig/src/util.rs
@@ -1,5 +1,6 @@
 elrond_wasm::imports!();
 
+use eth_address::EthAddress;
 use transaction::SingleTransferTuple;
 
 use crate::action::Action;
@@ -119,14 +120,17 @@ pub trait UtilModule: crate::storage::StorageModule {
 
     fn transfers_multiarg_to_tuples_vec(
         &self,
-        transfers: ManagedVarArgs<MultiArg3<ManagedAddress, TokenIdentifier, BigUint>>,
+        transfers: ManagedVarArgs<
+            MultiArg4<EthAddress<Self::Api>, ManagedAddress, TokenIdentifier, BigUint>,
+        >,
     ) -> ManagedVec<SingleTransferTuple<Self::Api>> {
         let mut transfers_as_tuples = ManagedVec::new();
         for transfer in transfers {
-            let (address, token_id, amount) = transfer.into_tuple();
+            let (from, to, token_id, amount) = transfer.into_tuple();
 
             transfers_as_tuples.push(SingleTransferTuple {
-                address,
+                from,
+                to,
                 token_id,
                 amount,
             });

--- a/multisig/wasm/src/lib.rs
+++ b/multisig/wasm/src/lib.rs
@@ -31,6 +31,7 @@ elrond_wasm_node::wasm_endpoints! {
         getAllBoardMembers
         getAllStakedRelayers
         getAmountStaked
+        getCurrentRefundBatch
         getCurrentTxBatch
         getErc20AddressForTokenId
         getEsdtSafeAddress
@@ -40,7 +41,6 @@ elrond_wasm_node::wasm_endpoints! {
         getRequiredStakeAmount
         getSlashAmount
         getSlashedTokensAmount
-        getStatusesAfterExecution
         getTokenIdForErc20Address
         isPaused
         multiTransferEsdtRemoveTokenFromWhitelist


### PR DESCRIPTION
- the Ethereum -> Elrond flow no longer returns statuses
- any transactions marked as failed are saved in a batch, using the same code as the Elrond -> Ethereum batches
- a new view was added, which will return said failed transaction batches

In next PR(s):
- Actual clearing and processing of said refund batches
- Propose with batch ID instead of action ID, with the contract doing the mapping(batchID -> actionID) internally
- Checking that batch IDs are in incremental order for Ethereum -> Elrond batches