### PR TITLE
move refunds from MultiTransferEsdt to EsdtSafe

### DIFF
--- a/common/transaction/src/lib.rs
+++ b/common/transaction/src/lib.rs
@@ -37,7 +37,7 @@ pub struct SingleTransferTuple<M: ManagedTypeApi> {
     pub amount: BigUint<M>,
 }
 
-#[derive(NestedEncode, NestedDecode, TypeAbi, ManagedVecItem)]
+#[derive(NestedEncode, NestedDecode, TypeAbi, ManagedVecItem, Clone)]
 pub struct Transaction<M: ManagedTypeApi> {
     pub block_nonce: BlockNonce,
     pub nonce: TxNonce,

--- a/common/transaction/src/lib.rs
+++ b/common/transaction/src/lib.rs
@@ -45,6 +45,7 @@ pub struct Transaction<M: ManagedTypeApi> {
     pub to: ManagedBuffer<M>,
     pub token_identifier: TokenIdentifier<M>,
     pub amount: BigUint<M>,
+    pub is_refund_tx: bool,
 }
 
 impl<M: ManagedTypeApi> From<TxAsMultiResult<M>> for Transaction<M> {
@@ -59,6 +60,7 @@ impl<M: ManagedTypeApi> From<TxAsMultiResult<M>> for Transaction<M> {
             to,
             token_identifier,
             amount,
+            is_refund_tx: false,
         }
     }
 }

--- a/esdt-safe/mandos/add_refund_batch.scen.json
+++ b/esdt-safe/mandos/add_refund_batch.scen.json
@@ -1,25 +1,43 @@
 {
-    "name": "user2 creates a tx as well",
+    "name": "add refund batch",
     "steps": [
         {
             "step": "externalSteps",
-            "path": "create_transaction_ok.scen.json"
+            "path": "create_another_tx_ok.scen.json"
+        },
+        {
+            "step": "setState",
+            "currentBlockInfo": {
+                "blockNonce": "5"
+            }
         },
         {
             "step": "scCall",
-            "txId": "user2-create-transaction-ok",
+            "txId": "add-refund-batch",
             "tx": {
-                "from": "address:user2",
+                "from": "address:owner",
                 "to": "sc:esdt_safe",
-                "esdt": {
-                    "tokenIdentifier": "str:BRIDGE-123456",
-                    "value": "1,500,900"
-                },
-                "function": "createTransaction",
+                "function": "addRefundBatch",
                 "arguments": [
-                    "0x0102030405060708091011121314151617181920"
+                    {
+                        "01-block_nonce": "u64:2",
+                        "02-nonce": "u64:1",
+                        "03-from": "u32:20|0x0102030405060708091011121314151617181920",
+                        "04-to": "u32:32|address:user1",
+                        "05-token_identifier": "nested:str:BRIDGE-123456",
+                        "06-amount": "biguint:2,000,000",
+                        "07-is_refund_tx": "u8:1",
+
+                        "11-block_nonce": "u64:3",
+                        "12-nonce": "u64:2",
+                        "13-from": "u32:20|0x0102030405060708091011121314151617181920",
+                        "14-to": "u32:32|address:user2",
+                        "15-token_identifier": "nested:str:BRIDGE-123456",
+                        "16-amount": "biguint:3,000,000",
+                        "17-is_refund_tx": "u8:1"
+                    }
                 ],
-                "gasLimit": "50,000,000",
+                "gasLimit": "100,000,000",
                 "gasPrice": "0"
             },
             "expect": {
@@ -39,14 +57,6 @@
         {
             "step": "checkState",
             "accounts": {
-                "address:user2": {
-                    "nonce": "*",
-                    "balance": "0",
-                    "esdt": {
-                        "str:BRIDGE-123456": "499,100"
-                    },
-                    "storage": {}
-                },
                 "sc:esdt_safe": {
                     "nonce": "0",
                     "balance": "0",
@@ -77,12 +87,30 @@
                                 "5-token_identifier": "nested:str:BRIDGE-123456",
                                 "6-amount": "biguint:900",
                                 "7-is_refund_tx": "u8:0"
+                            },
+                            {
+                                "1-block_nonce": "u64:5",
+                                "2-nonce": "u64:3",
+                                "3-from": "u32:32|address:user1",
+                                "4-to": "u32:20|0x0102030405060708091011121314151617181920",
+                                "5-token_identifier": "nested:str:BRIDGE-123456",
+                                "6-amount": "biguint:500,000",
+                                "7-is_refund_tx": "u8:1"
+                            },
+                            {
+                                "1-block_nonce": "u64:5",
+                                "2-nonce": "u64:4",
+                                "3-from": "u32:32|address:user2",
+                                "4-to": "u32:20|0x0102030405060708091011121314151617181920",
+                                "5-token_identifier": "nested:str:BRIDGE-123456",
+                                "6-amount": "biguint:1,500,000",
+                                "7-is_refund_tx": "u8:1"
                             }
                         ],
                         "str:firstBatchId": "0",
                         "str:lastBatchId": "0",
 
-                        "str:accumulatedTransactionFees|nested:str:BRIDGE-123456": "3,000,000",
+                        "str:accumulatedTransactionFees|nested:str:BRIDGE-123456": "6,000,000",
 
                         "+": ""
                     },

--- a/esdt-safe/mandos/create_another_tx_too_late_for_batch.scen.json
+++ b/esdt-safe/mandos/create_another_tx_too_late_for_batch.scen.json
@@ -82,7 +82,8 @@
                                 "3-from": "u32:32|address:user1",
                                 "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                                 "5-token_identifier": "nested:str:BRIDGE-123456",
-                                "6-amount": "biguint:400"
+                                "6-amount": "biguint:400",
+                                "7-is_refund_tx": "u8:0"
                             },
                             {
                                 "1-block_nonce": "u64:0",
@@ -90,7 +91,8 @@
                                 "3-from": "u32:32|address:user2",
                                 "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                                 "5-token_identifier": "nested:str:BRIDGE-123456",
-                                "6-amount": "biguint:900"
+                                "6-amount": "biguint:900",
+                                "7-is_refund_tx": "u8:0"
                             }
                         ],
                         "str:pendingBatches|u64:1": {
@@ -99,7 +101,8 @@
                             "3-from": "u32:32|address:user2",
                             "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                             "5-token_identifier": "nested:str:BRIDGE-123456",
-                            "6-amount": "biguint:100"
+                            "6-amount": "biguint:100",
+                            "7-is_refund_tx": "u8:0"
                         },
 
                         "str:firstBatchId": "0",

--- a/esdt-safe/mandos/create_transaction_ok.scen.json
+++ b/esdt-safe/mandos/create_transaction_ok.scen.json
@@ -65,7 +65,8 @@
                             "3-from": "u32:32|address:user1",
                             "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                             "5-token_identifier": "nested:str:BRIDGE-123456",
-                            "6-amount": "biguint:400"
+                            "6-amount": "biguint:400",
+                            "7-is_refund_tx": "u8:0"
                         },
                         "str:firstBatchId": "0",
                         "str:lastBatchId": "0",

--- a/esdt-safe/mandos/zero_fees.scen.json
+++ b/esdt-safe/mandos/zero_fees.scen.json
@@ -104,7 +104,8 @@
                             "3-from": "u32:32|address:user1",
                             "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                             "5-token_identifier": "nested:str:BRIDGE-123456",
-                            "6-amount": "biguint:1,500,400"
+                            "6-amount": "biguint:1,500,400",
+                            "7-is_refund_tx": "u8:0"
                         },
                         "str:firstBatchId": "0",
                         "str:lastBatchId": "0",

--- a/esdt-safe/src/lib.rs
+++ b/esdt-safe/src/lib.rs
@@ -102,6 +102,7 @@ pub trait EsdtSafe:
         let block_nonce = self.blockchain().get_block_nonce();
         let mut cached_token_ids = ManagedVec::new();
         let mut cached_prices = ManagedVec::new();
+        let mut new_transactions = ManagedVec::new();
 
         for refund_tx in &refund_transactions {
             let required_fee = match cached_token_ids
@@ -138,9 +139,10 @@ pub trait EsdtSafe:
                 amount: actual_bridged_amount,
                 is_refund_tx: true,
             };
-
-            self.add_to_batch(new_tx);
+            new_transactions.push(new_tx);
         }
+
+        self.add_multiple_tx_to_batch(new_transactions);
     }
 
     // endpoints

--- a/esdt-safe/wasm/src/lib.rs
+++ b/esdt-safe/wasm/src/lib.rs
@@ -8,6 +8,7 @@ elrond_wasm_node::wasm_endpoints! {
     esdt_safe
     (
         init
+        addRefundBatch
         addTokenToWhitelist
         calculateRequiredFee
         claimRefund

--- a/multi-transfer-esdt/mandos/batch_transfer_both_failed.scen.json
+++ b/multi-transfer-esdt/mandos/batch_transfer_both_failed.scen.json
@@ -73,6 +73,54 @@
                     "100,500"
                 ]
             }
+        },
+        {
+            "step": "scCall",
+            "txId": "clear-refund-batch",
+            "tx": {
+                "from": "address:owner",
+                "to": "sc:multi_transfer_esdt",
+                "value": "0",
+                "function": "getAndClearFirstRefundBatch",
+                "arguments": [],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "message": "",
+                "out": [
+                    "0",
+
+                    "0",
+                    "1",
+                    "0x0102030405060708091011121314151617181920",
+                    "sc:multi_transfer_esdt",
+                    "str:BRIDGE-123456",
+                    "100,200",
+
+                    "0",
+                    "2",
+                    "0x0102030405060708091011121314151617181920",
+                    "sc:multi_transfer_esdt",
+                    "str:WRAPPED-123456",
+                    "100,500"
+                ],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scQuery",
+            "txId": "get-current-refund-tx-batch-after-clear",
+            "tx": {
+                "to": "sc:multi_transfer_esdt",
+                "function": "getCurrentTxBatch",
+                "arguments": []
+            },
+            "expect": {
+                "out": []
+            }
         }
     ]
 }

--- a/multi-transfer-esdt/wasm/src/lib.rs
+++ b/multi-transfer-esdt/wasm/src/lib.rs
@@ -13,6 +13,7 @@ elrond_wasm_node::wasm_endpoints! {
         calculateRequiredFee
         distributeFees
         getAllKnownTokens
+        getAndClearFirstRefundBatch
         getBatch
         getCurrentTxBatch
         getDefaultPricePerGasUnit

--- a/multisig/mandos/create_elrond_to_ethereum_tx_batch.scen.json
+++ b/multisig/mandos/create_elrond_to_ethereum_tx_batch.scen.json
@@ -124,7 +124,8 @@
                             "3-from": "u32:32|address:user",
                             "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                             "5-token_identifier": "nested:str:EGLD-123456",
-                            "6-amount": "biguint:400"
+                            "6-amount": "biguint:400",
+                            "7-is_refund_tx": "u8:0"
                         },
                         "str:firstBatchId": "0",
                         "str:lastBatchId": "0",
@@ -206,7 +207,8 @@
                                 "3-from": "u32:32|address:user",
                                 "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                                 "5-token_identifier": "nested:str:EGLD-123456",
-                                "6-amount": "biguint:400"
+                                "6-amount": "biguint:400",
+                                "7-is_refund_tx": "u8:0"
                             },
                             {
                                 "1-block_nonce": "u64:0",
@@ -214,7 +216,8 @@
                                 "3-from": "u32:32|address:user",
                                 "4-to": "u32:20|0x0102030405060708091011121314151617181920",
                                 "5-token_identifier": "nested:str:ETH-123456",
-                                "6-amount": "biguint:350,000"
+                                "6-amount": "biguint:350,000",
+                                "7-is_refund_tx": "u8:0"
                             }
                         ],
                         "str:firstBatchId": "0",

--- a/multisig/mandos/ethereum_to_elrond_tx_batch_rejected.scen.json
+++ b/multisig/mandos/ethereum_to_elrond_tx_batch_rejected.scen.json
@@ -15,8 +15,8 @@
                 "function": "proposeMultiTransferEsdtBatch",
                 "arguments": [
                     "1",
-                    "0x0102030405060708091011121314151617181920", "sc:egld_esdt_swap", "str:EGLD-123456", "500,000",
-                    "0x0102030405060708091011121314151617181920", "sc:egld_esdt_swap", "str:ETH-123456", "500,000"
+                    "0x0102030405060708091011121314151617181920", "sc:egld_esdt_swap", "str:EGLD-123456", "2,000,000",
+                    "0x0102030405060708091011121314151617181920", "sc:egld_esdt_swap", "str:ETH-123456", "2,000,000"
                 ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"
@@ -47,13 +47,13 @@
                                     "1-from": "0x0102030405060708091011121314151617181920",
                                     "2-to": "sc:egld_esdt_swap",
                                     "3-token_id": "nested:str:EGLD-123456",
-                                    "4-amount": "biguint:500,000"
+                                    "4-amount": "biguint:2,000,000"
                                 },
                                 {
                                     "1-from": "0x0102030405060708091011121314151617181920",
                                     "2-to": "sc:egld_esdt_swap",
                                     "3-token_id": "nested:str:ETH-123456",
-                                    "4-amount": "biguint:500,000"
+                                    "4-amount": "biguint:2,000,000"
                                 }
                             ]
                         },
@@ -132,15 +132,122 @@
                     "0x0102030405060708091011121314151617181920",
                     "sc:egld_esdt_swap",
                     "str:EGLD-123456",
-                    "500,000",
+                    "2,000,000",
 
                     "0",
                     "2",
                     "0x0102030405060708091011121314151617181920",
                     "sc:egld_esdt_swap",
                     "str:ETH-123456",
-                    "500,000"
+                    "2,000,000"
                 ]
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "move-refund-batch-to-safe",
+            "comment": "output is from execute_on_dest_context results being propagated to the initial caller",
+            "tx": {
+                "from": "address:owner",
+                "to": "sc:multisig",
+                "value": "0",
+                "function": "moveRefundBatchToSafe",
+                "arguments": [],
+                "gasLimit": "200,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "0",
+                "message": "",
+                "out": [
+                    "0",
+
+                    "0",
+                    "1",
+                    "0x0102030405060708091011121314151617181920",
+                    "sc:egld_esdt_swap",
+                    "str:EGLD-123456",
+                    "2,000,000",
+
+                    "0",
+                    "2",
+                    "0x0102030405060708091011121314151617181920",
+                    "sc:egld_esdt_swap",
+                    "str:ETH-123456",
+                    "2,000,000",
+
+                    "1", "str:GWEI", "str:EGLD", "10", "0",
+                    "1", "str:GWEI", "str:ETH", "1", "0"
+                ],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scQuery",
+            "txId": "get-current-refund-tx-batch-after-move",
+            "tx": {
+                "to": "sc:multisig",
+                "function": "getCurrentRefundBatch",
+                "arguments": []
+            },
+            "expect": {
+                "out": []
+            }
+        },
+        {
+            "step": "checkState",
+            "accounts": {
+                "sc:esdt_safe": {
+                    "nonce": "0",
+                    "balance": "0",
+                    "esdt": {
+                        "str:EGLD-123456": {
+                            "balance": "0",
+                            "roles": [
+                                "ESDTRoleLocalBurn"
+                            ]
+                        },
+                        "str:ETH-123456": {
+                            "balance": "0",
+                            "roles": [
+                                "ESDTRoleLocalBurn"
+                            ]
+                        }
+                    },
+                    "storage": {
+                        "str:pendingBatches|u64:0": [
+                            {
+                                "1-block_nonce": "u64:4,000",
+                                "2-nonce": "u64:1",
+                                "3-from": "u32:32|sc:egld_esdt_swap",
+                                "4-to": "u32:20|0x0102030405060708091011121314151617181920",
+                                "5-token_identifier": "nested:str:EGLD-123456",
+                                "6-amount": "biguint:500,000",
+                                "7-is_refund_tx": "u8:1"
+                            },
+                            {
+                                "1-block_nonce": "u64:4,000",
+                                "2-nonce": "u64:2",
+                                "3-from": "u32:32|sc:egld_esdt_swap",
+                                "4-to": "u32:20|0x0102030405060708091011121314151617181920",
+                                "5-token_identifier": "nested:str:ETH-123456",
+                                "6-amount": "biguint:1,850,000",
+                                "7-is_refund_tx": "u8:1"
+                            }
+                        ],
+                        "str:firstBatchId": "0",
+                        "str:lastBatchId": "0",
+
+                        "str:accumulatedTransactionFees|nested:str:EGLD-123456": "1,500,000",
+                        "str:accumulatedTransactionFees|nested:str:ETH-123456": "150,000",
+
+
+                        "+": ""
+                    },
+                    "code": "*"
+                },
+                "+": {}
             }
         }
     ]

--- a/multisig/src/setup.rs
+++ b/multisig/src/setup.rs
@@ -264,6 +264,25 @@ pub trait SetupModule:
             .execute_on_dest_context();
     }
 
+    #[only_owner]
+    #[endpoint(multiTransferEsdtSetMaxRefundTxBatchSize)]
+    fn multi_transfer_esdt_set_max_refund_tx_batch_size(&self, new_max_tx_batch_size: usize) {
+        self.setup_get_multi_transfer_esdt_proxy_instance()
+            .set_max_tx_batch_size(new_max_tx_batch_size)
+            .execute_on_dest_context();
+    }
+
+    #[only_owner]
+    #[endpoint(multiTransferEsdtSetMaxRefundTxBatchBlockDuration)]
+    fn multi_transfer_esdt_set_max_refund_tx_batch_block_duration(
+        &self,
+        new_max_tx_batch_block_duration: u64,
+    ) {
+        self.setup_get_multi_transfer_esdt_proxy_instance()
+            .set_max_tx_batch_block_duration(new_max_tx_batch_block_duration)
+            .execute_on_dest_context();
+    }
+
     // proxies
 
     #[proxy]

--- a/multisig/wasm/src/lib.rs
+++ b/multisig/wasm/src/lib.rs
@@ -43,7 +43,10 @@ elrond_wasm_node::wasm_endpoints! {
         getSlashedTokensAmount
         getTokenIdForErc20Address
         isPaused
+        moveRefundBatchToSafe
         multiTransferEsdtRemoveTokenFromWhitelist
+        multiTransferEsdtSetMaxRefundTxBatchBlockDuration
+        multiTransferEsdtSetMaxRefundTxBatchSize
         multiTransferEsdtaddTokenToWhitelist
         pause
         performAction


### PR DESCRIPTION
- added owner-only function in the Multisig contract, which moves refund batches from MultiTransferEsdt (i.e. failed Eth -> Elrond tx) into the EsdtSafe, converting them into Elrond -> Eth transactions.