### PR TITLE
Storage optimization

### DIFF
--- a/multisig/src/lib.rs
+++ b/multisig/src/lib.rs
@@ -357,8 +357,8 @@ pub trait Multisig:
         eth_batch_id: u64,
         #[var_args] transfers: ManagedVarArgs<EthTxAsMultiArg<Self::Api>>,
     ) -> usize {
-        let transfers_as_tuples = self.transfers_multiarg_to_eth_tx_vec(transfers);
-        let result_batch_hash = self.hash_eth_tx_batch(&transfers_as_tuples);
+        let transfers_as_struct = self.transfers_multiarg_to_eth_tx_vec(transfers);
+        let result_batch_hash = self.hash_eth_tx_batch(&transfers_as_struct);
 
         match result_batch_hash {
             Ok(batch_hash) => self

--- a/multisig/src/lib.rs
+++ b/multisig/src/lib.rs
@@ -225,7 +225,7 @@ pub trait Multisig:
         let transfers_as_eth_tx = self.transfers_multiarg_to_eth_tx_vec(transfers);
         self.require_valid_eth_tx_ids(&transfers_as_eth_tx)?;
 
-        let batch_hash = self.hash_eth_tx_batch(&transfers_as_eth_tx);
+        let batch_hash = self.hash_eth_tx_batch(&transfers_as_eth_tx)?;
         require!(
             self.batch_id_to_action_id_mapping(eth_batch_id)
                 .get(&batch_hash)
@@ -358,11 +358,15 @@ pub trait Multisig:
         #[var_args] transfers: ManagedVarArgs<EthTxAsMultiArg<Self::Api>>,
     ) -> usize {
         let transfers_as_tuples = self.transfers_multiarg_to_eth_tx_vec(transfers);
-        let batch_hash = self.hash_eth_tx_batch(&transfers_as_tuples);
+        let result_batch_hash = self.hash_eth_tx_batch(&transfers_as_tuples);
 
-        self.batch_id_to_action_id_mapping(eth_batch_id)
-            .get(&batch_hash)
-            .unwrap_or(0)
+        match result_batch_hash {
+            Ok(batch_hash) => self
+                .batch_id_to_action_id_mapping(eth_batch_id)
+                .get(&batch_hash)
+                .unwrap_or(0),
+            Err(_) => 0,
+        }
     }
 
     #[view(wasSetCurrentTransactionBatchStatusActionProposed)]

--- a/multisig/src/storage.rs
+++ b/multisig/src/storage.rs
@@ -3,10 +3,11 @@ elrond_wasm::derive_imports!();
 
 use eth_address::EthAddress;
 use transaction::transaction_status::TransactionStatus;
-use transaction::EthTransaction;
 
 use crate::action::Action;
 use crate::user_role::UserRole;
+
+pub type EthBatchHash<M> = ManagedByteArray<M, 32>; // keccak256(ManagedVec<EthTransaction<Self::Api>)
 
 #[elrond_wasm::module]
 pub trait StorageModule {
@@ -69,7 +70,7 @@ pub trait StorageModule {
     fn batch_id_to_action_id_mapping(
         &self,
         batch_id: u64,
-    ) -> MapMapper<ManagedVec<EthTransaction<Self::Api>>, usize>;
+    ) -> MapMapper<EthBatchHash<Self::Api>, usize>;
 
     #[storage_mapper("actionIdForSetCurrentTransactionBatchStatus")]
     fn action_id_for_set_current_transaction_batch_status(

--- a/multisig/src/util.rs
+++ b/multisig/src/util.rs
@@ -157,10 +157,10 @@ pub trait UtilModule: crate::storage::StorageModule {
     fn hash_eth_tx_batch(
         &self,
         eth_tx_batch: &ManagedVec<EthTransaction<Self::Api>>,
-    ) -> EthBatchHash<Self::Api> {
+    ) -> SCResult<EthBatchHash<Self::Api>> {
         let mut serialized = ManagedBuffer::new();
-        let _ = eth_tx_batch.top_encode(&mut serialized);
+        eth_tx_batch.top_encode(&mut serialized)?;
 
-        self.raw_vm_api().keccak256(&serialized)
+        Ok(self.raw_vm_api().keccak256(&serialized))
     }
 }

--- a/multisig/src/util.rs
+++ b/multisig/src/util.rs
@@ -1,8 +1,10 @@
 elrond_wasm::imports!();
+use elrond_wasm::elrond_codec::TopEncode;
 
 use transaction::{EthTransaction, EthTxAsMultiArg};
 
 use crate::action::Action;
+use crate::storage::EthBatchHash;
 use crate::user_role::UserRole;
 
 #[elrond_wasm::module]
@@ -150,5 +152,15 @@ pub trait UtilModule: crate::storage::StorageModule {
         }
 
         Ok(())
+    }
+
+    fn hash_eth_tx_batch(
+        &self,
+        eth_tx_batch: &ManagedVec<EthTransaction<Self::Api>>,
+    ) -> EthBatchHash<Self::Api> {
+        let mut serialized = ManagedBuffer::new();
+        let _ = eth_tx_batch.top_encode(&mut serialized);
+
+        self.raw_vm_api().keccak256(&serialized)
     }
 }


### PR DESCRIPTION
When doing the mapping of (Eth -> Elrond batch, action ID), only store the hash instead of the whole batch.