### PR TITLE
accumulated fees fix for refund tx

### DIFF
--- a/esdt-safe/mandos/add_refund_batch.scen.json
+++ b/esdt-safe/mandos/add_refund_batch.scen.json
@@ -110,7 +110,7 @@
                         "str:firstBatchId": "1",
                         "str:lastBatchId": "1",
 
-                        "str:accumulatedTransactionFees|nested:str:BRIDGE-123456": "6,000,000",
+                        "str:accumulatedTransactionFees|nested:str:BRIDGE-123456": "3,000,000",
 
                         "+": ""
                     },

--- a/esdt-safe/src/lib.rs
+++ b/esdt-safe/src/lib.rs
@@ -132,9 +132,6 @@ pub trait EsdtSafe:
                 continue;
             }
 
-            self.accumulated_transaction_fees(&refund_tx.token_identifier)
-                .update(|fees| *fees += &required_fee);
-
             let actual_bridged_amount = refund_tx.amount - required_fee;
             let tx_nonce = self.get_and_save_next_tx_id();
 

--- a/multisig/mandos/ethereum_to_elrond_tx_batch_rejected.scen.json
+++ b/multisig/mandos/ethereum_to_elrond_tx_batch_rejected.scen.json
@@ -283,8 +283,8 @@
                         "str:firstBatchId": "1",
                         "str:lastBatchId": "1",
 
-                        "str:accumulatedTransactionFees|nested:str:EGLD-123456": "1,500,000",
-                        "str:accumulatedTransactionFees|nested:str:ETH-123456": "150,000",
+                        "str:accumulatedTransactionFees|nested:str:EGLD-123456": "0",
+                        "str:accumulatedTransactionFees|nested:str:ETH-123456": "0",
 
 
                         "+": ""


### PR DESCRIPTION
- for refund transactions, EsdtSafe does not actually have the tokens, so fees cannot be taken